### PR TITLE
Update fetch content 0731

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -25,7 +25,7 @@ class SearchConfig:
     DEFAULT_SUMMARY_RESULTS = 5
     
     # Web fetching configuration
-    MAX_CONTENT_LENGTH = 1000
+    MAX_CONTENT_LENGTH = 10000
     FETCH_TIMEOUT = 30.0
     USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -25,7 +25,7 @@ class SearchConfig:
     DEFAULT_SUMMARY_RESULTS = 5
     
     # Web fetching configuration
-    MAX_CONTENT_LENGTH = 8000
+    MAX_CONTENT_LENGTH = 1000
     FETCH_TIMEOUT = 30.0
     USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
 

--- a/src/server/handlers.py
+++ b/src/server/handlers.py
@@ -64,11 +64,12 @@ class SearchHandlers:
             Dictionary containing the parsed content or error information
         """
         try:
-            content = await self.fetcher.fetch_and_parse(url)
+            content, is_truncated = await self.fetcher.fetch_and_parse(url)
             return {
                 "url": url,
                 "content": content,
                 "content_length": len(content),
+                "is_truncated": is_truncated,
                 "success": True
             }
         except SearchException as e:

--- a/src/server/mcp_server.py
+++ b/src/server/mcp_server.py
@@ -3,7 +3,9 @@ FastMCP Server for exposing search functionality
 Provides general web search capabilities via SearxNG
 """
 
+import argparse
 import sys
+from typing import Any, Dict
 from fastmcp import FastMCP
 from .handlers import SearchHandlers
 
@@ -28,8 +30,12 @@ def search(query: str, max_results: int = 10):
     return handlers.search(query, max_results)
 
 
-@mcp.tool
-async def fetch_content(url: str):
+@mcp.tool(
+    name="fetch_content",
+    tags={"web", "fetch"},
+    enabled=True,
+)
+async def fetch_content(url: str) -> Dict[str, Any]:
     """
     Fetch and parse content from a webpage URL.
     
@@ -43,15 +49,25 @@ async def fetch_content(url: str):
 
 
 def run_server():
-    """Run the MCP server with appropriate transport."""
-    # Check for HTTP mode flag
-    if len(sys.argv) > 1 and sys.argv[1] == "--http":
-        # Run with HTTP transport on port 3090
-        mcp.run(transport="http", host="0.0.0.0", port=3090)
-        print("Server running on http://0.0.0.0:3090")
+    """Run the MCP server with appropriate transport and configurable port."""
+    # args
+    parser = argparse.ArgumentParser(description="Run MCP server with configurable transport and port")
+    parser.add_argument('--port', type=int, default=3090, help='Port number for HTTP transport (default: 3090)')
+    parser.add_argument('--http', action='store_true', help='Run server with HTTP transport')
+    parser.add_argument('--sse', action='store_true', help='Run server with SSE transport')
+    args = parser.parse_args()
+
+    # Run server with appropriate transport and port
+    if args.http:
+        mcp.run(transport="http", host="0.0.0.0", port=args.port)
+        print(f"Server running on http://0.0.0.0:{args.port} with HTTP transport")
+    elif args.sse:
+        mcp.run(transport="sse", host="0.0.0.0", port=args.port)
+        print(f"Server running on http://0.0.0.0:{args.port} with SSE transport")
     else:
-        # Default stdio transport for MCP
-        mcp.run()
+        mcp.run(transport="http", host="0.0.0.0", port=args.port)
+        print(f"Server running on http://0.0.0.0:{args.port} with HTTP transport")
+
 
 
 if __name__ == "__main__":

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -21,7 +21,7 @@ class TestWebContentFetcher:
         # Use a reliable test URL
         url = "https://httpbin.org/html"
         
-        content = await self.fetcher.fetch_and_parse(url)
+        content, _ = await self.fetcher.fetch_and_parse(url)
         
         assert isinstance(content, str)
         assert len(content) > 0
@@ -49,7 +49,7 @@ class TestWebContentFetcher:
         # httpbin.org/html has known HTML structure
         url = "https://httpbin.org/html"
         
-        content = await self.fetcher.fetch_and_parse(url)
+        content, _ = await self.fetcher.fetch_and_parse(url)
         
         # Should not contain HTML tags
         assert "<" not in content


### PR DESCRIPTION
Summary
- Increased content truncation for fetch_content() to 10,000 characters, was 8k
- Added more website sections to not return to user
  - ["script", "style", "nav", "header", "footer", "aside", "advertisement", "ads", "sidebar", "menu", "widget", "banner"]
- Added content truncated flag to llm response