### PR TITLE
feat: add search filters (categories, time_range, language)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 - **`search`** — Web search via SearxNG
   - `query` (required) — search terms
   - `max_results` (optional, default: 10, max: 25)
+  - `categories` (optional) — comma-separated: `general`, `news`, `science`, `it`, `music`
+  - `time_range` (optional) — `day`, `month`, or `year`
+  - `language` (optional) — ISO language code (e.g., `en`, `de`, `fr`)
   - Returns: title, url, content snippet, score
 
 - **`search_videos`** — YouTube video search
@@ -98,6 +101,10 @@ Add to `.cursor/mcp.json` in your project:
 
 ```bash
 mcporter call webintel-mcp.search query="latest news" max_results=5
+
+# Search with filters
+mcporter call webintel-mcp.search query="AI breakthroughs" categories="science" time_range="month"
+mcporter call webintel-mcp.search query="open source LLM" categories="news" time_range="day" language="en"
 mcporter call webintel-mcp.fetch_content url="https://example.com"
 mcporter call webintel-mcp.fetch_subreddit subreddit="python" sort="top" time_filter="week"
 ```

--- a/src/core/search.py
+++ b/src/core/search.py
@@ -34,6 +34,8 @@ class SearxngClient:
         query: str, 
         engines: Union[str, List[str]] = None, 
         categories: Union[str, List[str]] = None, 
+        time_range: Optional[str] = None,
+        language: Optional[str] = None,
         max_results: int = None
     ) -> RawSearxngResponse:
         """
@@ -43,6 +45,8 @@ class SearxngClient:
             query: The search query
             engines: Search engines to use
             categories: Search categories to use
+            time_range: Time filter ('day', 'month', 'year')
+            language: Language code filter (e.g., 'en', 'de', 'fr')
             max_results: Maximum number of results to return
             
         Returns:
@@ -67,6 +71,12 @@ class SearxngClient:
             else:
                 params['categories'] = categories
         
+        if time_range:
+            params['time_range'] = time_range
+        
+        if language:
+            params['language'] = language
+        
         try:
             response = requests.get(
                 url, 
@@ -90,7 +100,10 @@ class SearxngClient:
     def search_general(
         self, 
         query: str, 
-        max_results: int = None
+        max_results: int = None,
+        categories: Optional[str] = None,
+        time_range: Optional[str] = None,
+        language: Optional[str] = None
     ) -> List[GeneralSearchResult]:
         """
         Perform a general web search and return cleaned results.
@@ -98,6 +111,9 @@ class SearxngClient:
         Args:
             query: The search query
             max_results: Maximum number of results to return
+            categories: Search categories (e.g., 'general', 'news', 'science')
+            time_range: Time filter ('day', 'month', 'year')
+            language: Language code filter (e.g., 'en', 'de')
             
         Returns:
             List of GeneralSearchResult objects
@@ -107,7 +123,13 @@ class SearxngClient:
         elif max_results > SearchConfig.MAX_GENERAL_RESULTS:
             max_results = SearchConfig.MAX_GENERAL_RESULTS
         
-        raw_response = self._search_raw(query, max_results=max_results)
+        raw_response = self._search_raw(
+            query, 
+            categories=categories,
+            time_range=time_range,
+            language=language,
+            max_results=max_results
+        )
         
         results = []
         for result in raw_response.results:

--- a/src/server/handlers.py
+++ b/src/server/handlers.py
@@ -31,13 +31,23 @@ class SearchHandlers:
         self.youtube_fetcher = YouTubeContentFetcher()
         self.reddit_fetcher = RedditFetcher()
     
-    def search(self, query: str, max_results: int = 10) -> List[SearchResultOutput]:
+    def search(
+        self, 
+        query: str, 
+        max_results: int = 10,
+        categories: str = None,
+        time_range: str = None,
+        language: str = None
+    ) -> List[SearchResultOutput]:
         """
         Perform a general web search using SearxNG.
         
         Args:
             query: The search query to execute
             max_results: Maximum number of results to return (default: 10, max: 25)
+            categories: Search categories (e.g., 'general', 'news', 'science', 'it', 'music')
+            time_range: Time filter ('day', 'month', 'year')
+            language: Language code filter (e.g., 'en', 'de', 'fr')
             
         Returns:
             List of search results with title, url, content, score
@@ -52,9 +62,28 @@ class SearchHandlers:
         elif max_results < 1:
             max_results = 1
         
+        # Validate time_range
+        valid_time_ranges = ['day', 'month', 'year']
+        if time_range and time_range not in valid_time_ranges:
+            raise ToolError(f"Invalid time_range: '{time_range}'. Must be one of: {valid_time_ranges}")
+        
+        # Validate categories
+        valid_categories = ['general', 'news', 'science', 'it', 'music', 'images', 'videos', 'files', 'social_media', 'map']
+        if categories:
+            for cat in categories.split(','):
+                cat = cat.strip()
+                if cat not in valid_categories:
+                    raise ToolError(f"Invalid category: '{cat}'. Must be one of: {valid_categories}")
+        
         try:
             # Call the search function
-            results = self.client.search_general(query, max_results=max_results)
+            results = self.client.search_general(
+                query, 
+                max_results=max_results,
+                categories=categories,
+                time_range=time_range,
+                language=language
+            )
             
             # Convert to output models
             return [

--- a/src/server/mcp_server.py
+++ b/src/server/mcp_server.py
@@ -6,7 +6,7 @@ Provides general web search capabilities via SearxNG
 import argparse
 import os
 import sys
-from typing import List, Annotated
+from typing import List, Annotated, Optional
 from pydantic import Field
 from fastmcp import FastMCP
 from .handlers import SearchHandlers
@@ -44,15 +44,26 @@ def search(
         description="Maximum number of results to return (default: 10, min: 1, max: 25)",
         ge=1,
         le=25
-    )] = 10
+    )] = 10,
+    categories: Annotated[Optional[str], Field(
+        description="Comma-separated search categories: general, news, science, it, music (default: general)"
+    )] = None,
+    time_range: Annotated[Optional[str], Field(
+        description="Time filter: 'day', 'month', or 'year' (default: no filter)"
+    )] = None,
+    language: Annotated[Optional[str], Field(
+        description="Language code for results (e.g., 'en', 'de', 'fr'). Default: all languages"
+    )] = None
 ) -> List[SearchResultOutput]:
     """
     Perform a general web search using SearxNG.
     
+    Supports filtering by category, time range, and language.
+    
     Returns:
         List of search results with title, url, content, score
     """
-    return handlers.search(query, max_results)
+    return handlers.search(query, max_results, categories, time_range, language)
 
 
 @mcp.tool(

--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -1,0 +1,199 @@
+"""Tests for search filter parameters (categories, time_range, language)."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from src.server.handlers import SearchHandlers
+from src.core.models import GeneralSearchResult, RawSearxngResponse, RawResult
+
+
+def _mock_raw_response(num_results=1):
+    """Create a mock SearxNG response."""
+    results = []
+    for i in range(num_results):
+        results.append(RawResult(
+            url=f"https://example.com/{i}",
+            title=f"Result {i}",
+            content=f"Content {i}",
+            engine="google",
+            score=10.0 - i
+        ))
+    return RawSearxngResponse(
+        query="test",
+        number_of_results=num_results,
+        results=results
+    )
+
+
+class TestSearchFiltersValidation:
+    """Test input validation for search filters."""
+
+    def setup_method(self):
+        self.handlers = SearchHandlers()
+
+    def test_valid_time_range_day(self):
+        """'day' should be accepted as time_range."""
+        with patch.object(self.handlers.client, 'search_general', return_value=[]) as mock:
+            self.handlers.search("test", time_range="day")
+            mock.assert_called_once_with("test", max_results=10, categories=None, time_range="day", language=None)
+
+    def test_valid_time_range_month(self):
+        """'month' should be accepted as time_range."""
+        with patch.object(self.handlers.client, 'search_general', return_value=[]) as mock:
+            self.handlers.search("test", time_range="month")
+            mock.assert_called_once_with("test", max_results=10, categories=None, time_range="month", language=None)
+
+    def test_valid_time_range_year(self):
+        """'year' should be accepted as time_range."""
+        with patch.object(self.handlers.client, 'search_general', return_value=[]) as mock:
+            self.handlers.search("test", time_range="year")
+            mock.assert_called_once_with("test", max_results=10, categories=None, time_range="year", language=None)
+
+    def test_invalid_time_range_rejected(self):
+        """Invalid time_range values should raise ToolError."""
+        from fastmcp.exceptions import ToolError
+        with pytest.raises(ToolError, match="Invalid time_range"):
+            self.handlers.search("test", time_range="week")
+
+    def test_valid_category_general(self):
+        """'general' should be accepted as category."""
+        with patch.object(self.handlers.client, 'search_general', return_value=[]) as mock:
+            self.handlers.search("test", categories="general")
+            mock.assert_called_once_with("test", max_results=10, categories="general", time_range=None, language=None)
+
+    def test_valid_category_news(self):
+        """'news' should be accepted as category."""
+        with patch.object(self.handlers.client, 'search_general', return_value=[]) as mock:
+            self.handlers.search("test", categories="news")
+            mock.assert_called_once()
+
+    def test_valid_category_science(self):
+        """'science' should be accepted as category."""
+        with patch.object(self.handlers.client, 'search_general', return_value=[]) as mock:
+            self.handlers.search("test", categories="science")
+            mock.assert_called_once()
+
+    def test_valid_category_it(self):
+        """'it' should be accepted as category."""
+        with patch.object(self.handlers.client, 'search_general', return_value=[]) as mock:
+            self.handlers.search("test", categories="it")
+            mock.assert_called_once()
+
+    def test_valid_category_music(self):
+        """'music' should be accepted as category."""
+        with patch.object(self.handlers.client, 'search_general', return_value=[]) as mock:
+            self.handlers.search("test", categories="music")
+            mock.assert_called_once()
+
+    def test_valid_multiple_categories(self):
+        """Comma-separated categories should be accepted."""
+        with patch.object(self.handlers.client, 'search_general', return_value=[]) as mock:
+            self.handlers.search("test", categories="news,science")
+            mock.assert_called_once_with("test", max_results=10, categories="news,science", time_range=None, language=None)
+
+    def test_invalid_category_rejected(self):
+        """Invalid category values should raise ToolError."""
+        from fastmcp.exceptions import ToolError
+        with pytest.raises(ToolError, match="Invalid category"):
+            self.handlers.search("test", categories="invalid")
+
+    def test_language_passed_through(self):
+        """Language parameter should be passed through to backend."""
+        with patch.object(self.handlers.client, 'search_general', return_value=[]) as mock:
+            self.handlers.search("test", language="en")
+            mock.assert_called_once_with("test", max_results=10, categories=None, time_range=None, language="en")
+
+    def test_all_filters_combined(self):
+        """All filters should work together."""
+        with patch.object(self.handlers.client, 'search_general', return_value=[]) as mock:
+            self.handlers.search("test", categories="news", time_range="day", language="de")
+            mock.assert_called_once_with("test", max_results=10, categories="news", time_range="day", language="de")
+
+    def test_none_filters_default(self):
+        """None filters should not be sent to backend."""
+        with patch.object(self.handlers.client, 'search_general', return_value=[]) as mock:
+            self.handlers.search("test")
+            mock.assert_called_once_with("test", max_results=10, categories=None, time_range=None, language=None)
+
+
+class TestSearchBackendFilters:
+    """Test that filters are correctly passed to SearxNG API."""
+
+    def test_time_range_in_params(self):
+        """time_range should be added to SearxNG request params."""
+        from src.core.search import SearxngClient
+        client = SearxngClient("http://localhost:8080")
+        
+        with patch('src.core.search.requests.get') as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "query": "test", "number_of_results": 0, "results": []
+            }
+            mock_get.return_value = mock_response
+            
+            client.search_general("test", time_range="day")
+            
+            call_args = mock_get.call_args
+            params = call_args[1].get('params', call_args[0][1] if len(call_args[0]) > 1 else {})
+            if not params:
+                params = call_args.kwargs.get('params', {})
+            assert params.get('time_range') == 'day'
+
+    def test_language_in_params(self):
+        """language should be added to SearxNG request params."""
+        from src.core.search import SearxngClient
+        client = SearxngClient("http://localhost:8080")
+        
+        with patch('src.core.search.requests.get') as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "query": "test", "number_of_results": 0, "results": []
+            }
+            mock_get.return_value = mock_response
+            
+            client.search_general("test", language="fr")
+            
+            call_args = mock_get.call_args
+            params = call_args.kwargs.get('params', {})
+            assert params.get('language') == 'fr'
+
+    def test_categories_in_params(self):
+        """categories should be added to SearxNG request params."""
+        from src.core.search import SearxngClient
+        client = SearxngClient("http://localhost:8080")
+        
+        with patch('src.core.search.requests.get') as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "query": "test", "number_of_results": 0, "results": []
+            }
+            mock_get.return_value = mock_response
+            
+            client.search_general("test", categories="science")
+            
+            call_args = mock_get.call_args
+            params = call_args.kwargs.get('params', {})
+            assert params.get('categories') == 'science'
+
+    def test_no_filters_clean_params(self):
+        """Without filters, params should only have q and format."""
+        from src.core.search import SearxngClient
+        client = SearxngClient("http://localhost:8080")
+        
+        with patch('src.core.search.requests.get') as mock_get:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "query": "test", "number_of_results": 0, "results": []
+            }
+            mock_get.return_value = mock_response
+            
+            client.search_general("test")
+            
+            call_args = mock_get.call_args
+            params = call_args.kwargs.get('params', {})
+            assert 'time_range' not in params
+            assert 'language' not in params
+            assert 'categories' not in params


### PR DESCRIPTION
Adds optional filtering parameters to the `search` tool:

- **categories** — filter by SearxNG category (general, images, videos, news, etc.)
- **time_range** — limit results by time (day, week, month, year)
- **language** — language code for results (e.g. en, de, fr)

Includes tests and README updates.