### PR TITLE
fix: add build directive to webintel-mcp service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       start_period: 10s
 
   webintel-mcp:
+    build: .
     image: webintel-mcp:latest
     container_name: webintel-mcp
     ports:


### PR DESCRIPTION
Adds `build: .` to the webintel-mcp service in docker-compose.yml so that `docker compose up -d --build` actually rebuilds the image from the Dockerfile.

Previously, only `image:` was set with no `build:` directive, meaning compose restarts reused stale images and code changes weren't picked up without a manual `docker build`.