### PR TITLE
feat: auto JS rendering fallback for fetch_content

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR /app
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYTHONPATH=/app
+    PYTHONPATH=/app \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -33,6 +34,9 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 # Install yt-dlp nightly (--pre) for latest YouTube fixes
 RUN pip install --no-cache-dir -U --pre "yt-dlp[default]"
+
+# Install Playwright browsers for JS rendering support
+RUN playwright install --with-deps chromium
 
 # Copy the entire src directory and its structure
 COPY src/ ./src/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 - **`fetch_content`** — Fetch and extract readable content from any URL
   - `url` (required) — URL to fetch
   - `offset` (optional, default: 0) — pagination offset
+  - Automatic fallback chain: static fetch → JS rendering (if empty) → Jina Reader (if still empty/error)
   - Content is returned in 30K character chunks. Use `next_offset` from the response to paginate.
 
 - **`fetch_youtube_content`** — Download and transcribe YouTube video audio
@@ -198,6 +199,17 @@ python -m src.server.mcp_server
 # Run tests
 python -m pytest tests/ -v --ignore=tests/test_searxng_integration.py
 ```
+
+### JS Rendering (Auto Fallback)
+
+`fetch_content` automatically falls back to headless browser rendering when static fetch returns empty content. This requires **Playwright** with Chromium:
+
+```bash
+pip install playwright
+playwright install chromium
+```
+
+The Docker image includes Playwright and Chromium. For local development, install them separately.
 
 ### YouTube Transcription Requirements
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,13 @@
 # Core dependencies
 fastmcp>=3.0.0b1
 pydantic>=2.0.0
-beautifulsoup4>=4.12.0
+trafilatura>=2.0.0
 openai>=1.0.0
 httpx>=0.25.0
 requests>=2.31.0
+
+# Browser rendering (optional, for render_js support)
+playwright>=1.40.0
 
 # YouTube transcription
 yt-dlp>=2026.2.0

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -27,6 +27,7 @@ class SearchConfig:
     # Web fetching configuration
     MAX_CONTENT_LENGTH = 30000
     FETCH_TIMEOUT = 30.0
+    RENDER_TIMEOUT = 30.0  # Timeout for JS rendering with Playwright (seconds)
     USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
     
     # YouTube STT configuration

--- a/src/core/web_fetcher.py
+++ b/src/core/web_fetcher.py
@@ -172,12 +172,18 @@ class WebContentFetcher:
                 
         except httpx.TimeoutException:
             # Fallback to Jina Reader API for any timeout
-            content, was_truncated = await self._fetch_via_jina(url)
-            return self._apply_offset_and_chunk(content, offset)
+            try:
+                content, was_truncated = await self._fetch_via_jina(url)
+                return self._apply_offset_and_chunk(content, offset)
+            except SearchException:
+                raise SearchException(f"Failed to fetch {url}")
 
         except httpx.HTTPError as e:
             # Fallback to Jina Reader API for HTTP errors
-            content, was_truncated = await self._fetch_via_jina(url)
-            return self._apply_offset_and_chunk(content, offset)
+            try:
+                content, was_truncated = await self._fetch_via_jina(url)
+                return self._apply_offset_and_chunk(content, offset)
+            except SearchException:
+                raise SearchException(f"Failed to fetch {url}")
         except Exception as e:
             raise SearchException(f"Unexpected error while fetching content: {str(e)}")

--- a/src/core/web_fetcher.py
+++ b/src/core/web_fetcher.py
@@ -2,20 +2,25 @@
 Web content fetching functionality
 """
 
-import re
 import httpx
-from bs4 import BeautifulSoup
+import trafilatura
+from lxml.html import fromstring, tostring
+from lxml.html.clean import Cleaner
 from .config import SearchConfig, SearchException
-        
+
 
 class WebContentFetcher:
     """Handles fetching and parsing web content."""
-    
+
+    # Singleton browser instance (lazy init)
+    _playwright = None
+    _browser = None
+
     def __init__(self):
         self.headers = {
             "User-Agent": SearchConfig.USER_AGENT
         }
-    
+
     def _is_pdf_url(self, url: str) -> bool:
         """Check if URL points to a PDF file based on URL patterns."""
         url_lower = url.lower()
@@ -28,15 +33,96 @@ class WebContentFetcher:
 
     def _is_pdf_content(self, content_type: str, content_start: bytes) -> bool:
         """Check if content is PDF based on headers and magic numbers."""
-        # Check Content-Type header
         if content_type and 'application/pdf' in content_type.lower():
             return True
-
-        # Check PDF magic numbers
         if content_start and content_start.startswith(b'%PDF'):
             return True
-
         return False
+
+    @staticmethod
+    def _clean_browser_html(html: str) -> str:
+        """
+        Strip scripts, styles, noscript tags, and HTML comments from
+        browser-rendered HTML so trafilatura can extract main content.
+
+        Falls back to returning the original HTML if cleaning fails.
+        """
+        try:
+            cleaner = Cleaner(
+                scripts=True,
+                javascript=True,
+                style=True,
+                comments=True,
+                page_structure=False,
+                remove_tags=["noscript"],
+            )
+            doc = fromstring(html)
+            cleaned = cleaner.clean_html(doc)
+            return tostring(cleaned, encoding="unicode")
+        except Exception:
+            return html
+
+    async def _launch_browser(self):
+        """Launch a new Playwright browser, closing any stale instances first."""
+        if WebContentFetcher._playwright is not None:
+            try:
+                await WebContentFetcher._playwright.stop()
+            except Exception:
+                pass
+        from playwright.async_api import async_playwright
+        WebContentFetcher._playwright = await async_playwright().start()
+        WebContentFetcher._browser = await WebContentFetcher._playwright.chromium.launch(
+            headless=True,
+            args=[
+                "--disable-dev-shm-usage",
+                "--no-sandbox",
+                "--single-process",
+            ],
+        )
+        return WebContentFetcher._browser
+
+    async def _ensure_browser(self):
+        """Lazily initialize the Playwright browser singleton, re-launching if crashed."""
+        if WebContentFetcher._browser is None or not WebContentFetcher._browser.is_connected():
+            return await self._launch_browser()
+        return WebContentFetcher._browser
+
+    async def _render_with_browser(self, url: str) -> str:
+        """
+        Render a page in a headless browser and return the rendered HTML.
+
+        Uses Playwright to load the page, wait for network idle,
+        and extract the final DOM content.
+
+        Args:
+            url: The URL to render
+
+        Returns:
+            Rendered HTML string
+
+        Raises:
+            SearchException: If rendering fails entirely
+        """
+        browser = await self._ensure_browser()
+        try:
+            page = await browser.new_page()
+        except Exception:
+            # Browser died between check and use — re-launch once
+            browser = await self._launch_browser()
+            page = await browser.new_page()
+        try:
+            timeout_ms = int(SearchConfig.RENDER_TIMEOUT * 1000)
+            try:
+                await page.goto(url, wait_until="networkidle", timeout=timeout_ms)
+            except Exception:
+                # Timeout or navigation error — extract whatever HTML is available
+                pass
+            html = await page.content()
+            return html
+        except Exception as e:
+            raise SearchException(f"Browser rendering failed for {url}: {str(e)}")
+        finally:
+            await page.close()
 
     async def _fetch_via_jina(self, url: str) -> tuple[str, bool]:
         """Fetch content using Jina Reader API."""
@@ -49,87 +135,105 @@ class WebContentFetcher:
                     )
                 response.raise_for_status()
 
-                # Truncate if too long 
                 is_truncated = False
                 text = response.text
                 if len(text) > SearchConfig.MAX_CONTENT_LENGTH:
                     text = text[:SearchConfig.MAX_CONTENT_LENGTH] + "... [content truncated]"
                     is_truncated = True
-                
+
                 return text, is_truncated
-            
+
         except Exception as e:
             raise SearchException(f"Failed to fetch via Jina Reader: {e}")
 
     def _apply_offset_and_chunk(self, content: str, offset: int) -> tuple[str, bool, int, int]:
         """
         Apply offset and chunk the content.
-        
+
         Args:
             content: Full content text
             offset: Starting position
-            
+
         Returns:
             Tuple of (content_chunk, is_truncated, next_offset, total_length)
         """
         total_length = len(content)
-        
-        # If offset is beyond content, return empty
+
         if offset >= total_length:
             return "", False, total_length, total_length
-        
-        # Calculate end position
+
         end_pos = min(offset + SearchConfig.MAX_CONTENT_LENGTH, total_length)
-        
-        # Extract chunk
         content_chunk = content[offset:end_pos]
-        
-        # Determine if truncated
         is_truncated = end_pos < total_length
-        
-        # Calculate next offset
         next_offset = end_pos if is_truncated else total_length
-        
+
         return content_chunk, is_truncated, next_offset, total_length
-    
-    async def _parse_html_content(self, html_content: str) -> str:
-        """Parse HTML content and extract text."""
-        try:
-            soup = BeautifulSoup(html_content, "lxml")
-        except Exception as e:
-            soup = BeautifulSoup(html_content, "html.parser")
 
-        # Remove script and style elements
-        # TODO: evaluate more comprehensive approach
-        unwanted_tags = [
-            "script", "style", "nav", "header", "footer", "aside",
-            "advertisement", "ads", "sidebar", "menu", "widget", "banner"
-        ]
-        for element in soup(unwanted_tags):
-            element.decompose()
+    def _parse_html_content(self, html_content: str, url: str = None, favor_recall: bool = False) -> str:
+        """
+        Parse HTML content using trafilatura and extract text as Markdown.
 
-        # Get the text content
-        # TODO: evaluate Readability integration
-        text = soup.get_text()
+        Args:
+            html_content: Raw HTML string
+            url: Original URL (helps trafilatura with link resolution)
+            favor_recall: If True, use permissive extraction (for noisy browser-rendered HTML)
 
-        # Clean up the text
-        lines = (line.strip() for line in text.splitlines())
-        chunks = (phrase.strip() for line in lines for phrase in line.split(" "))
-        text = " ".join(chunk for chunk in chunks if chunk)
+        Returns:
+            Extracted content as Markdown string
+        """
+        # Primary extraction: trafilatura with Markdown output
+        text = trafilatura.extract(
+            html_content,
+            output_format="markdown",
+            include_links=True,
+            include_formatting=True,
+            include_tables=True,
+            url=url,
+            favor_recall=favor_recall,
+        )
 
-        # Remove extra whitespace
-        text = re.sub(r"\s+", " ", text).strip()
+        # Fallback chain if trafilatura returns None
+        if not text:
+            result = trafilatura.bare_extraction(html_content, url=url, favor_recall=favor_recall)
+            if result:
+                doc = result if isinstance(result, dict) else result.as_dict()
+                text = doc.get("text", "")
+                if text:
+                    return text
+
+            # Last resort: extract all text
+            text = trafilatura.html2txt(html_content)
+            if not text:
+                text = ""
 
         return text
+
+    async def _try_browser_fallback(self, url: str) -> str | None:
+        """
+        Attempt JS rendering fallback: render with browser, clean HTML, extract text.
+
+        Returns extracted text or None if browser fails or yields empty content.
+        """
+        try:
+            html = await self._render_with_browser(url)
+            html = self._clean_browser_html(html)
+            text = self._parse_html_content(html, url=url, favor_recall=True)
+            if text and text.strip():
+                return text
+        except Exception:
+            pass
+        return None
 
     async def fetch_and_parse(self, url: str, offset: int = 0) -> tuple[str, bool, int, int]:
         """
         Fetch and parse content from a webpage or PDF.
 
+        Fallback chain: static fetch → JS render (if empty) → Jina (if still empty/error).
+
         Args:
             url: The webpage URL to fetch content from
             offset: Starting position for content retrieval (default: 0)
-            
+
         Returns:
             Tuple of (parsed_text, is_truncated, next_offset, total_length)
 
@@ -137,16 +241,15 @@ class WebContentFetcher:
             SearchException: If fetching or parsing fails
         """
         try:
-            # Validate offset
             if offset < 0:
                 offset = 0
-            
-            # Check if url is a PDF
+
+            # PDFs always go through Jina
             if self._is_pdf_url(url):
                 content, was_truncated = await self._fetch_via_jina(url)
                 return self._apply_offset_and_chunk(content, offset)
 
-            # request
+            # Standard static fetch path
             async with httpx.AsyncClient(proxy=SearchConfig.PROXY_URL) as client:
                 response = await client.get(
                     url,
@@ -155,7 +258,7 @@ class WebContentFetcher:
                     timeout=SearchConfig.FETCH_TIMEOUT,
                 )
                 response.raise_for_status()
-                
+
                 # Check if the response is a PDF
                 content_type = response.headers.get('content-type', '')
                 content_start = response.content[:8] if response.content else b''
@@ -164,14 +267,29 @@ class WebContentFetcher:
                     content, was_truncated = await self._fetch_via_jina(url)
                     return self._apply_offset_and_chunk(content, offset)
 
-                # Parse as HTML
-                text = await self._parse_html_content(response.text)
+                # Parse as HTML with trafilatura
+                text = self._parse_html_content(response.text, url=url)
 
-                # Apply offset and chunking
-                return self._apply_offset_and_chunk(text, offset)
-                
+                # If static extraction returned content, return it
+                if text and text.strip():
+                    return self._apply_offset_and_chunk(text, offset)
+
+                # Empty static result → try JS rendering fallback
+                browser_text = await self._try_browser_fallback(url)
+                if browser_text:
+                    return self._apply_offset_and_chunk(browser_text, offset)
+
+                # Still empty → try Jina
+                content, was_truncated = await self._fetch_via_jina(url)
+                return self._apply_offset_and_chunk(content, offset)
+
+        except SearchException:
+            raise
         except httpx.TimeoutException:
-            # Fallback to Jina Reader API for any timeout
+            # Static fetch timed out → try browser, then Jina
+            browser_text = await self._try_browser_fallback(url)
+            if browser_text:
+                return self._apply_offset_and_chunk(browser_text, offset)
             try:
                 content, was_truncated = await self._fetch_via_jina(url)
                 return self._apply_offset_and_chunk(content, offset)
@@ -179,7 +297,10 @@ class WebContentFetcher:
                 raise SearchException(f"Failed to fetch {url}")
 
         except httpx.HTTPError as e:
-            # Fallback to Jina Reader API for HTTP errors
+            # HTTP error → try browser, then Jina
+            browser_text = await self._try_browser_fallback(url)
+            if browser_text:
+                return self._apply_offset_and_chunk(browser_text, offset)
             try:
                 content, was_truncated = await self._fetch_via_jina(url)
                 return self._apply_offset_and_chunk(content, offset)

--- a/src/server/handlers.py
+++ b/src/server/handlers.py
@@ -144,18 +144,18 @@ class SearchHandlers:
     async def fetch_content(self, url: str, offset: int = 0) -> FetchContentOutput:
         """
         Fetch and parse content from a webpage URL with pagination support.
-        
+
         Args:
             url: The webpage URL to fetch content from
             offset: Starting position for content retrieval (default: 0)
-            
+
         Returns:
             FetchContentOutput containing the parsed content and pagination metadata
         """
         # Validate URL
         if not url or not url.strip():
             raise ToolError("URL cannot be empty")
-        
+
         try:
             content, is_truncated, next_offset, total_length = await self.fetcher.fetch_and_parse(url, offset)
             return FetchContentOutput(

--- a/src/server/mcp_server.py
+++ b/src/server/mcp_server.py
@@ -118,10 +118,10 @@ async def fetch_content(
 ) -> FetchContentOutput:
     """
     Fetch and parse content from a webpage URL with pagination support.
-    
+
     Content is retrieved in chunks of 30,000 characters. If content is truncated,
     use the returned 'next_offset' value in a subsequent call to retrieve the next chunk.
-    
+
     Returns:
         FetchContentOutput with parsed content and pagination metadata
     """

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -12,145 +12,113 @@ from src.core.config import SearchException
 
 class TestWebContentFetcher:
     """Test cases for WebContentFetcher."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
         self.fetcher = WebContentFetcher()
-    
+
     @pytest.mark.asyncio
     async def test_fetch_valid_url(self):
-        """Test fetching from a valid URL."""
-        # Use a reliable test URL
+        """Test fetching from a valid URL returns Markdown content."""
         url = "https://httpbin.org/html"
-        
+
         content, is_truncated, next_offset, total_length = await self.fetcher.fetch_and_parse(url)
-        
+
         assert isinstance(content, str)
         assert len(content) > 0
-        assert "Herman Melville" in content  # httpbin.org/html contains this
+        # httpbin.org/html contains a Moby Dick excerpt
+        assert any(term in content for term in ["Herman Melville", "Availing", "blacksmith"])
         assert isinstance(is_truncated, bool)
         assert isinstance(total_length, int)
-    
+
     @pytest.mark.asyncio
     async def test_fetch_invalid_url(self):
         """Test handling of invalid URL."""
         url = "https://this-domain-does-not-exist-12345.com"
-        
+
         with pytest.raises(SearchException):
             await self.fetcher.fetch_and_parse(url)
-    
+
     @pytest.mark.asyncio
     async def test_content_truncation(self):
         """Test that long content gets truncated."""
-        # This test would require a reliable URL with very long content
-        # For now, we can test the truncation logic by mocking or
-        # using a known URL with substantial content
         pass
-    
+
     @pytest.mark.asyncio
-    async def test_content_cleaning(self):
-        """Test that HTML content is properly cleaned."""
-        # httpbin.org/html has known HTML structure
+    async def test_content_is_markdown(self):
+        """Test that content is returned as Markdown, not plain text with tags stripped."""
         url = "https://httpbin.org/html"
-        
+
         content, is_truncated, next_offset, total_length = await self.fetcher.fetch_and_parse(url)
-        
-        # Should not contain HTML tags
-        assert "<" not in content
-        assert ">" not in content
-        
-        # Should contain readable text
+
         assert len(content.strip()) > 0
-    
+        assert "<script" not in content
+        assert "<style" not in content
+
     @pytest.mark.asyncio
     async def test_fetch_pdf_content(self):
-        """Test fetching and parsing PDF content using a real PDF URL."""        
+        """Test fetching and parsing PDF content using a real PDF URL."""
         pdf_url = "https://s28.q4cdn.com/823357996/files/doc_financials/2025/q1/DNA-Q1-2025-10Q.pdf"
         content, is_truncated, next_offset, total_length = await self.fetcher.fetch_and_parse(pdf_url)
-        
-        # Basic assertions
+
         assert content is not None
         assert isinstance(content, str)
         assert len(content) > 0
-        
-        # Should contain some expected financial document content
+
         text_lower = content.lower()
         assert any(term in text_lower for term in ["financial", "quarterly", "revenue", "10-q"])
-        
-        # Check truncation flag is boolean
+
         assert isinstance(is_truncated, bool)
         assert isinstance(total_length, int)
-    
+
     @pytest.mark.asyncio
     async def test_pagination_with_offset(self):
         """Test pagination with offset parameter."""
-        # Use PDF that's likely to be > 30K characters
         pdf_url = "https://s28.q4cdn.com/823357996/files/doc_financials/2025/q1/DNA-Q1-2025-10Q.pdf"
-        
-        # Fetch first chunk
+
         content1, is_truncated1, next_offset1, total_length1 = await self.fetcher.fetch_and_parse(pdf_url, offset=0)
-        
+
         if is_truncated1:
-            # Fetch second chunk using next_offset
             content2, is_truncated2, next_offset2, total_length2 = await self.fetcher.fetch_and_parse(pdf_url, offset=next_offset1)
-            
-            # Content should be different
+
             assert content1 != content2
-            
-            # Total length should be the same
             assert total_length1 == total_length2
-            
-            # next_offset should have advanced
             assert next_offset2 > next_offset1
-            
-            # Content lengths should be reasonable
             assert len(content1) > 0
             assert len(content2) > 0
-    
+
     @pytest.mark.asyncio
     async def test_offset_beyond_content(self):
         """Test offset beyond total content length."""
         url = "https://httpbin.org/html"
-        
-        # First get the total length
+
         _, _, _, total_length = await self.fetcher.fetch_and_parse(url)
-        
-        # Request with offset beyond content
+
         content, is_truncated, next_offset, total = await self.fetcher.fetch_and_parse(url, offset=total_length + 1000)
-        
-        # Should return empty content
+
         assert content == ""
         assert is_truncated is False
         assert next_offset == total_length
-    
+
     @pytest.mark.asyncio
     async def test_negative_offset(self):
         """Test that negative offset is treated as 0."""
         url = "https://httpbin.org/html"
-        
-        # Fetch with negative offset
+
         content1, _, _, _ = await self.fetcher.fetch_and_parse(url, offset=-100)
-        
-        # Fetch with offset 0
         content2, _, _, _ = await self.fetcher.fetch_and_parse(url, offset=0)
-        
-        # Should be identical
+
         assert content1 == content2
-    
+
     @pytest.mark.asyncio
     async def test_small_content_no_truncation(self):
         """Test that small content is not truncated."""
         url = "https://httpbin.org/html"
-        
+
         content, is_truncated, next_offset, total_length = await self.fetcher.fetch_and_parse(url)
-        
-        # Small content should not be truncated
+
         assert is_truncated is False
-        
-        # next_offset should equal total_length when not truncated
         assert next_offset == total_length
-        
-        # Content length should match total length
         assert len(content) == total_length
 
     @pytest.mark.asyncio
@@ -159,13 +127,11 @@ class TestWebContentFetcher:
         url = "https://example.com/some-page"
 
         with patch("src.core.web_fetcher.httpx.AsyncClient") as mock_client_cls:
-            # Make direct fetch raise TimeoutException
             mock_client = AsyncMock()
             mock_client.__aenter__.return_value = mock_client
             mock_client.get.side_effect = httpx.TimeoutException("timed out")
             mock_client_cls.return_value = mock_client
 
-            # Make Jina fallback also fail
             with patch.object(self.fetcher, "_fetch_via_jina", side_effect=SearchException("Jina broke")):
                 with pytest.raises(SearchException, match=f"Failed to fetch {url}"):
                     await self.fetcher.fetch_and_parse(url)
@@ -176,13 +142,278 @@ class TestWebContentFetcher:
         url = "https://example.com/some-page"
 
         with patch("src.core.web_fetcher.httpx.AsyncClient") as mock_client_cls:
-            # Make direct fetch raise HTTPError
             mock_client = AsyncMock()
             mock_client.__aenter__.return_value = mock_client
             mock_client.get.side_effect = httpx.HTTPError("503 Service Unavailable")
             mock_client_cls.return_value = mock_client
 
-            # Make Jina fallback also fail
             with patch.object(self.fetcher, "_fetch_via_jina", side_effect=SearchException("Jina broke")):
                 with pytest.raises(SearchException, match=f"Failed to fetch {url}"):
                     await self.fetcher.fetch_and_parse(url)
+
+    @pytest.mark.asyncio
+    async def test_trafilatura_fallback_on_empty(self):
+        """Test fallback chain when primary trafilatura extraction returns None."""
+        minimal_html = "<html><body><p>Short text.</p></body></html>"
+
+        with patch("src.core.web_fetcher.trafilatura.extract", return_value=None):
+            text = self.fetcher._parse_html_content(minimal_html)
+            assert isinstance(text, str)
+
+    # --- Auto JS rendering fallback tests ---
+
+    @pytest.mark.asyncio
+    async def test_browser_fallback_on_empty_static(self):
+        """When static fetch returns empty text, browser fallback is attempted."""
+        url = "https://example.com/spa"
+        browser_html = "<html><body><article><p>JS-rendered content here</p></article></body></html>"
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/html"}
+        mock_response.content = b"<html></html>"
+        mock_response.text = "<html><body></body></html>"
+        mock_response.raise_for_status = lambda: None
+
+        with patch("src.core.web_fetcher.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            with patch.object(self.fetcher, "_parse_html_content", side_effect=["", "JS-rendered content here"]):
+                with patch.object(self.fetcher, "_render_with_browser", new_callable=AsyncMock, return_value=browser_html) as mock_browser:
+                    content, _, _, _ = await self.fetcher.fetch_and_parse(url)
+
+                    mock_browser.assert_called_once_with(url)
+                    assert "JS-rendered content" in content
+
+    @pytest.mark.asyncio
+    async def test_render_timeout_extracts_partial(self):
+        """When static returns empty and browser returns partial HTML, content is extracted."""
+        url = "https://example.com/slow-spa"
+        partial_html = "<html><body><article><p>Partial content before timeout</p></article></body></html>"
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/html"}
+        mock_response.content = b"<html></html>"
+        mock_response.text = "<html><body></body></html>"
+        mock_response.raise_for_status = lambda: None
+
+        with patch("src.core.web_fetcher.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            with patch.object(self.fetcher, "_parse_html_content", side_effect=["", "Partial content before timeout"]):
+                with patch.object(self.fetcher, "_render_with_browser", new_callable=AsyncMock, return_value=partial_html):
+                    content, _, _, _ = await self.fetcher.fetch_and_parse(url)
+
+                    assert isinstance(content, str)
+                    assert len(content) > 0
+
+    @pytest.mark.asyncio
+    async def test_pdf_url_skips_browser_uses_jina(self):
+        """PDF URLs go straight to Jina, skipping both static parse and browser."""
+        pdf_url = "https://example.com/report.pdf"
+
+        with patch.object(self.fetcher, "_render_with_browser") as mock_browser:
+            with patch.object(self.fetcher, "_fetch_via_jina", new_callable=AsyncMock, return_value=("PDF content here", False)) as mock_jina:
+                content, _, _, _ = await self.fetcher.fetch_and_parse(pdf_url)
+
+                mock_browser.assert_not_called()
+                mock_jina.assert_called_once_with(pdf_url)
+                assert "PDF content" in content
+
+    @pytest.mark.asyncio
+    async def test_empty_static_and_browser_falls_back_to_jina(self):
+        """When both static fetch and browser return empty, Jina is used as last resort."""
+        url = "https://example.com/tricky-page"
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/html"}
+        mock_response.content = b"<html></html>"
+        mock_response.text = "<html><body></body></html>"
+        mock_response.raise_for_status = lambda: None
+
+        with patch("src.core.web_fetcher.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            with patch.object(self.fetcher, "_parse_html_content", return_value=""):
+                with patch.object(self.fetcher, "_render_with_browser", new_callable=AsyncMock, return_value="<html></html>"):
+                    with patch.object(self.fetcher, "_fetch_via_jina", new_callable=AsyncMock, return_value=("Jina content", False)) as mock_jina:
+                        content, _, _, _ = await self.fetcher.fetch_and_parse(url)
+
+                        mock_jina.assert_called_once_with(url)
+                        assert "Jina content" in content
+
+    @pytest.mark.asyncio
+    async def test_timeout_tries_browser_then_jina(self):
+        """When static fetch times out, browser is tried first, then Jina."""
+        url = "https://example.com/timeout-page"
+
+        with patch("src.core.web_fetcher.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.side_effect = httpx.TimeoutException("timed out")
+            mock_client_cls.return_value = mock_client
+
+            # Browser also fails → falls through to Jina
+            with patch.object(self.fetcher, "_try_browser_fallback", new_callable=AsyncMock, return_value=None) as mock_browser:
+                with patch.object(self.fetcher, "_fetch_via_jina", new_callable=AsyncMock, return_value=("Jina fallback", False)) as mock_jina:
+                    content, _, _, _ = await self.fetcher.fetch_and_parse(url)
+
+                    mock_browser.assert_called_once_with(url)
+                    mock_jina.assert_called_once_with(url)
+                    assert "Jina fallback" in content
+
+    @pytest.mark.asyncio
+    async def test_http_error_tries_browser_then_jina(self):
+        """When static fetch returns HTTP error, browser is tried first, then Jina."""
+        url = "https://example.com/error-page"
+
+        with patch("src.core.web_fetcher.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.side_effect = httpx.HTTPError("503 Service Unavailable")
+            mock_client_cls.return_value = mock_client
+
+            # Browser succeeds → no Jina needed
+            with patch.object(self.fetcher, "_try_browser_fallback", new_callable=AsyncMock, return_value="Browser content") as mock_browser:
+                with patch.object(self.fetcher, "_fetch_via_jina") as mock_jina:
+                    content, _, _, _ = await self.fetcher.fetch_and_parse(url)
+
+                    mock_browser.assert_called_once_with(url)
+                    mock_jina.assert_not_called()
+                    assert "Browser content" in content
+
+    # --- HTML cleaning tests ---
+
+    def test_clean_browser_html_removes_scripts_and_styles(self):
+        """Verify script, style, noscript tags and HTML comments are removed."""
+        noisy_html = """
+        <html><head>
+            <script>var x = 1;</script>
+            <style>body { color: red; }</style>
+        </head><body>
+            <!-- this is a comment -->
+            <noscript>Enable JS</noscript>
+            <article><p>Real content</p></article>
+            <script>alert('xss')</script>
+        </body></html>
+        """
+        cleaned = WebContentFetcher._clean_browser_html(noisy_html)
+
+        assert "<script" not in cleaned
+        assert "<style" not in cleaned
+        assert "<noscript" not in cleaned
+        assert "<!--" not in cleaned
+        assert "Real content" in cleaned
+
+    def test_clean_browser_html_preserves_content_structure(self):
+        """Verify semantic HTML elements are preserved after cleaning."""
+        html = """
+        <html><body>
+            <article><h1>Title</h1><p>Paragraph</p></article>
+            <a href="https://example.com">Link</a>
+            <ul><li>Item</li></ul>
+        </body></html>
+        """
+        cleaned = WebContentFetcher._clean_browser_html(html)
+
+        assert "<article" in cleaned
+        assert "<h1" in cleaned
+        assert "<p>" in cleaned or "<p " in cleaned
+        assert "<a " in cleaned
+        assert "<ul" in cleaned
+        assert "<li" in cleaned
+
+    def test_clean_browser_html_handles_malformed_html(self):
+        """Graceful fallback on malformed/empty input."""
+        # Empty string — should return original
+        assert WebContentFetcher._clean_browser_html("") == ""
+
+        # Not valid HTML at all — lxml may still parse it, but shouldn't crash
+        result = WebContentFetcher._clean_browser_html("just plain text, no tags")
+        assert isinstance(result, str)
+
+    @pytest.mark.asyncio
+    async def test_browser_fallback_cleans_html(self):
+        """Integration: noisy browser HTML is cleaned before trafilatura extraction in fallback."""
+        url = "https://example.com/spa"
+        noisy_html = """
+        <html><head>
+            <script src="app.js"></script>
+            <style>.cls { display: none; }</style>
+        </head><body>
+            <script>window.__DATA__ = {};</script>
+            <noscript>Please enable JavaScript</noscript>
+            <article><h1>Main Article</h1><p>This is the real content of the page.</p></article>
+            <script>trackEvent('view');</script>
+        </body></html>
+        """
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/html"}
+        mock_response.content = b"<html></html>"
+        mock_response.text = "<html><body></body></html>"
+        mock_response.raise_for_status = lambda: None
+
+        with patch("src.core.web_fetcher.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            # Static parse returns empty → triggers browser fallback
+            original_parse = self.fetcher._parse_html_content
+            call_count = [0]
+            def parse_side_effect(html, url=None, favor_recall=False):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    return ""  # Static path returns empty
+                return original_parse(html, url=url, favor_recall=favor_recall)
+
+            with patch.object(self.fetcher, "_parse_html_content", side_effect=parse_side_effect):
+                with patch.object(self.fetcher, "_render_with_browser", new_callable=AsyncMock, return_value=noisy_html):
+                    with patch.object(WebContentFetcher, "_clean_browser_html", wraps=WebContentFetcher._clean_browser_html) as mock_clean:
+                        content, _, _, _ = await self.fetcher.fetch_and_parse(url)
+
+                        mock_clean.assert_called_once()
+                        assert isinstance(content, str)
+                        assert len(content) > 0
+
+    @pytest.mark.asyncio
+    async def test_static_fetch_path_not_cleaned(self):
+        """Confirm the static fetch path does not call _clean_browser_html when content is found."""
+        url = "https://httpbin.org/html"
+
+        with patch.object(
+            WebContentFetcher, "_clean_browser_html", wraps=WebContentFetcher._clean_browser_html,
+        ) as mock_clean:
+            content, _, _, _ = await self.fetcher.fetch_and_parse(url)
+
+            mock_clean.assert_not_called()
+            assert len(content) > 0
+
+    @pytest.mark.asyncio
+    async def test_browser_lazy_singleton(self):
+        """Test that _ensure_browser returns existing browser when already initialized."""
+        original_browser = WebContentFetcher._browser
+        try:
+            # Set a fake browser as the singleton
+            mock_browser = AsyncMock()
+            mock_browser.is_connected = lambda: True
+            WebContentFetcher._browser = mock_browser
+
+            # _ensure_browser should return the existing instance without re-launching
+            result = await self.fetcher._ensure_browser()
+            assert result is mock_browser
+        finally:
+            WebContentFetcher._browser = original_browser

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -4,6 +4,8 @@ Tests for web content fetching functionality
 
 import pytest
 import asyncio
+from unittest.mock import AsyncMock, patch
+import httpx
 from src.core.web_fetcher import WebContentFetcher
 from src.core.config import SearchException
 
@@ -150,3 +152,37 @@ class TestWebContentFetcher:
         
         # Content length should match total length
         assert len(content) == total_length
+
+    @pytest.mark.asyncio
+    async def test_timeout_and_jina_failure_gives_simple_error(self):
+        """When direct fetch times out and Jina also fails, error message is simplified."""
+        url = "https://example.com/some-page"
+
+        with patch("src.core.web_fetcher.httpx.AsyncClient") as mock_client_cls:
+            # Make direct fetch raise TimeoutException
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.side_effect = httpx.TimeoutException("timed out")
+            mock_client_cls.return_value = mock_client
+
+            # Make Jina fallback also fail
+            with patch.object(self.fetcher, "_fetch_via_jina", side_effect=SearchException("Jina broke")):
+                with pytest.raises(SearchException, match=f"Failed to fetch {url}"):
+                    await self.fetcher.fetch_and_parse(url)
+
+    @pytest.mark.asyncio
+    async def test_http_error_and_jina_failure_gives_simple_error(self):
+        """When direct fetch returns HTTP error and Jina also fails, error message is simplified."""
+        url = "https://example.com/some-page"
+
+        with patch("src.core.web_fetcher.httpx.AsyncClient") as mock_client_cls:
+            # Make direct fetch raise HTTPError
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.side_effect = httpx.HTTPError("503 Service Unavailable")
+            mock_client_cls.return_value = mock_client
+
+            # Make Jina fallback also fail
+            with patch.object(self.fetcher, "_fetch_via_jina", side_effect=SearchException("Jina broke")):
+                with pytest.raises(SearchException, match=f"Failed to fetch {url}"):
+                    await self.fetcher.fetch_and_parse(url)


### PR DESCRIPTION
## Summary
- Add headless browser rendering (Playwright + Chromium) as an automatic fallback when static fetch returns empty content
- Remove the `render_js` user-facing parameter — JS rendering is now handled transparently via fallback chain: **static fetch → browser render → Jina Reader**
- Simplify error messages when both direct fetch and Jina fallback fail

## Changes
- **`src/core/web_fetcher.py`** — New `_try_browser_fallback()` helper; `fetch_and_parse()` uses auto fallback chain; `render_js` param removed
- **`src/server/handlers.py`** — Removed `render_js` from `fetch_content()`
- **`src/server/mcp_server.py`** — Removed `render_js` from MCP tool definition
- **`tests/test_fetch.py`** — Rewrote JS rendering tests for auto fallback behavior (24 tests passing)
- **`Dockerfile`** — Added Playwright + Chromium install
- **`requirements.txt`** — Added `trafilatura`, `playwright`
- **`README.md`** — Updated docs for auto fallback behavior

## Test plan
- [x] `pytest tests/test_fetch.py -v` — 24/24 passing
- [x] Docker build + service startup verified
- [x] Manual testing via MCP `fetch_content` — no `render_js` param, auto fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)