### PR TITLE
Fix Reddit tools with OAuth authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,18 @@ STT_API_KEY=dummy
 #
 PROXY_URL=
 
+# ===========================================
+# Reddit OAuth (required for Reddit tools)
+# ===========================================
+# Create a personal-use script app at https://www.reddit.com/prefs/apps
+REDDIT_CLIENT_ID=
+REDDIT_CLIENT_SECRET=
+REDDIT_USER_AGENT='python:webintel-mcp:v1.0.0 (by /u/YOUR_REDDIT_USERNAME)'
+
+# Optional. Leave empty to access Reddit directly even when PROXY_URL routes
+# other fetchers through a VPN. Reddit often blocks commercial VPN exit nodes.
+REDDIT_PROXY_URL=
+
 # Gluetun VPN Configuration (only needed when using --profile vpn)
 VPN_SERVICE_PROVIDER=custom
 VPN_TYPE=openvpn

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ cp .env.example .env
 | `STT_MODEL` | — | STT model name |
 | `STT_API_KEY` | — | STT API key |
 | `PROXY_URL` | — | HTTP proxy for outbound requests (e.g. `http://gluetun:8888`) |
+| `REDDIT_CLIENT_ID` | — | Client ID for a Reddit personal-use script app (required for Reddit tools) |
+| `REDDIT_CLIENT_SECRET` | — | Client secret for the Reddit app (required for Reddit tools) |
+| `REDDIT_USER_AGENT` | `python:webintel-mcp:v1.0.0` | Identifying Reddit User-Agent; include your Reddit username |
+| `REDDIT_PROXY_URL` | — | Optional Reddit-only proxy; empty means direct access even when `PROXY_URL` is set |
 | `VPN_SERVICE_PROVIDER` | — | Gluetun VPN provider (use `custom` for .ovpn files) |
 | `VPN_TYPE` | — | VPN type (`openvpn` or `wireguard`) |
 | `OPENVPN_USER` | — | VPN username |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,10 @@ services:
       - STT_MODEL
       - STT_API_KEY
       - PROXY_URL
+      - REDDIT_CLIENT_ID
+      - REDDIT_CLIENT_SECRET
+      - REDDIT_USER_AGENT
+      - REDDIT_PROXY_URL
       # Transport options: http (default) or sse
       - MCP_TRANSPORT=${MCP_TRANSPORT:-http}
       # Optional: override port (default: 3090)

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -39,6 +39,16 @@ class SearchConfig:
     # Convert empty string to None so httpx/yt-dlp use direct connection
     PROXY_URL = os.getenv('PROXY_URL') or None
 
+    # Reddit OAuth configuration. Reddit has separate proxy control because
+    # commercial VPN exit nodes are frequently blocked by Reddit.
+    REDDIT_CLIENT_ID = os.getenv('REDDIT_CLIENT_ID')
+    REDDIT_CLIENT_SECRET = os.getenv('REDDIT_CLIENT_SECRET')
+    REDDIT_USER_AGENT = os.getenv(
+        'REDDIT_USER_AGENT',
+        'python:webintel-mcp:v1.0.0'
+    )
+    REDDIT_PROXY_URL = os.getenv('REDDIT_PROXY_URL') or None
+
 
 class SearchException(Exception):
     """Custom exception for search-related errors."""

--- a/src/core/reddit_fetcher.py
+++ b/src/core/reddit_fetcher.py
@@ -1,21 +1,116 @@
-"""
-Reddit content fetching functionality using old.reddit.com API
-"""
+"""Reddit content fetching using Reddit's OAuth Data API."""
+
+import asyncio
+import time
+from typing import Optional
 
 import httpx
-from typing import Optional
+
 from .config import SearchConfig, SearchException
 
 
 class RedditFetcher:
-    """Handles fetching Reddit content via old.reddit.com JSON API."""
+    """Handles fetching Reddit content via the OAuth Data API."""
     
-    BASE_URL = "https://old.reddit.com"
+    BASE_URL = "https://oauth.reddit.com"
+    TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
+    TOKEN_EXPIRY_MARGIN = 60
     
     def __init__(self):
         self.headers = {
-            "User-Agent": SearchConfig.USER_AGENT
+            "User-Agent": SearchConfig.REDDIT_USER_AGENT
         }
+        self._access_token: Optional[str] = None
+        self._token_expires_at = 0.0
+        self._token_lock = asyncio.Lock()
+
+    def _validate_credentials(self) -> None:
+        if not SearchConfig.REDDIT_CLIENT_ID or not SearchConfig.REDDIT_CLIENT_SECRET:
+            raise SearchException(
+                "Reddit OAuth is not configured. Set REDDIT_CLIENT_ID and "
+                "REDDIT_CLIENT_SECRET."
+            )
+
+    async def _get_access_token(self, force_refresh: bool = False) -> str:
+        """Return a cached application-only OAuth token."""
+        self._validate_credentials()
+        now = time.monotonic()
+        if not force_refresh and self._access_token and now < self._token_expires_at:
+            return self._access_token
+
+        async with self._token_lock:
+            now = time.monotonic()
+            if not force_refresh and self._access_token and now < self._token_expires_at:
+                return self._access_token
+
+            try:
+                async with httpx.AsyncClient(proxy=SearchConfig.REDDIT_PROXY_URL) as client:
+                    response = await client.post(
+                        self.TOKEN_URL,
+                        auth=(
+                            SearchConfig.REDDIT_CLIENT_ID,
+                            SearchConfig.REDDIT_CLIENT_SECRET,
+                        ),
+                        headers=self.headers,
+                        data={"grant_type": "client_credentials"},
+                        timeout=SearchConfig.FETCH_TIMEOUT,
+                    )
+                    response.raise_for_status()
+                    payload = response.json()
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 401:
+                    raise SearchException(
+                        "Reddit rejected the OAuth client ID or client secret"
+                    )
+                raise SearchException(
+                    f"Reddit OAuth token request failed with HTTP {e.response.status_code}"
+                )
+            except httpx.TimeoutException:
+                raise SearchException("Reddit OAuth token request timed out")
+            except httpx.HTTPError as e:
+                raise SearchException(f"Reddit OAuth token request failed: {e}")
+
+            token = payload.get("access_token")
+            if not token:
+                raise SearchException("Reddit OAuth response did not contain an access token")
+
+            expires_in = max(int(payload.get("expires_in", 3600)), 0)
+            self._access_token = token
+            self._token_expires_at = time.monotonic() + max(
+                expires_in - self.TOKEN_EXPIRY_MARGIN, 0
+            )
+            return token
+
+    async def _get(self, url: str, params: dict) -> httpx.Response:
+        """Make an authenticated request, refreshing once if the token expired."""
+        for attempt in range(2):
+            token = await self._get_access_token(force_refresh=attempt == 1)
+            headers = {**self.headers, "Authorization": f"bearer {token}"}
+            async with httpx.AsyncClient(proxy=SearchConfig.REDDIT_PROXY_URL) as client:
+                response = await client.get(
+                    url,
+                    headers=headers,
+                    params=params,
+                    follow_redirects=True,
+                    timeout=SearchConfig.FETCH_TIMEOUT,
+                )
+            if response.status_code != 401 or attempt == 1:
+                response.raise_for_status()
+                return response
+
+            self._access_token = None
+            self._token_expires_at = 0.0
+
+        raise SearchException("Reddit authentication failed")
+
+    @staticmethod
+    def _rate_limit_message(response: httpx.Response) -> str:
+        retry_after = response.headers.get("retry-after")
+        reset = response.headers.get("x-ratelimit-reset")
+        wait = retry_after or reset
+        if wait:
+            return f"Reddit rate limit exceeded; retry in {wait} seconds"
+        return "Reddit rate limit exceeded; retry later"
     
     async def fetch_subreddit_posts(
         self,
@@ -64,26 +159,25 @@ class RedditFetcher:
             params["after"] = after
         
         try:
-            async with httpx.AsyncClient(proxy=SearchConfig.PROXY_URL) as client:
-                response = await client.get(
-                    url,
-                    headers=self.headers,
-                    params=params,
-                    follow_redirects=True,
-                    timeout=SearchConfig.FETCH_TIMEOUT,
-                )
-                response.raise_for_status()
-                return response.json()
+            response = await self._get(url, params)
+            return response.json()
                 
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
                 raise SearchException(f"Subreddit not found: r/{subreddit}")
             elif e.response.status_code == 403:
-                raise SearchException(f"Access forbidden to r/{subreddit} (private or banned)")
+                raise SearchException(
+                    f"Reddit denied access to r/{subreddit}; it may be private, banned, "
+                    "or unavailable to this OAuth application"
+                )
+            elif e.response.status_code == 429:
+                raise SearchException(self._rate_limit_message(e.response))
             else:
                 raise SearchException(f"HTTP error {e.response.status_code}: {str(e)}")
         except httpx.TimeoutException:
             raise SearchException("Request timed out while fetching subreddit posts")
+        except SearchException:
+            raise
         except Exception as e:
             raise SearchException(f"Failed to fetch subreddit posts: {str(e)}")
     
@@ -146,25 +240,24 @@ class RedditFetcher:
             params["context"] = context
         
         try:
-            async with httpx.AsyncClient(proxy=SearchConfig.PROXY_URL) as client:
-                response = await client.get(
-                    url,
-                    headers=self.headers,
-                    params=params,
-                    follow_redirects=True,
-                    timeout=SearchConfig.FETCH_TIMEOUT,
-                )
-                response.raise_for_status()
-                return response.json()
+            response = await self._get(url, params)
+            return response.json()
                 
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
                 raise SearchException(f"Post not found: {post_id} in r/{subreddit}")
             elif e.response.status_code == 403:
-                raise SearchException(f"Access forbidden to post or subreddit")
+                raise SearchException(
+                    "Reddit denied access to the post; it may be private, banned, "
+                    "or unavailable to this OAuth application"
+                )
+            elif e.response.status_code == 429:
+                raise SearchException(self._rate_limit_message(e.response))
             else:
                 raise SearchException(f"HTTP error {e.response.status_code}: {str(e)}")
         except httpx.TimeoutException:
             raise SearchException("Request timed out while fetching post")
+        except SearchException:
+            raise
         except Exception as e:
             raise SearchException(f"Failed to fetch post: {str(e)}")

--- a/src/server/mcp_server.py
+++ b/src/server/mcp_server.py
@@ -189,7 +189,7 @@ async def fetch_subreddit(
     )] = None
 ) -> SubredditPostsOutput:
     """
-    Fetch posts from a subreddit using old.reddit.com API.
+    Fetch posts from a subreddit using Reddit's OAuth Data API.
     
     Retrieves a list of posts with title, author, score, comments count,
     and other metadata. Supports pagination via the 'after' cursor.
@@ -240,7 +240,7 @@ async def fetch_subreddit_post(
     )] = None
 ) -> RedditPostOutput:
     """
-    Fetch a Reddit post with its comments using old.reddit.com API.
+    Fetch a Reddit post with its comments using Reddit's OAuth Data API.
     
     Retrieves the post content including title, body, media URLs, and all
     comments with nested replies maintaining parent-child relationships.

--- a/tests/test_reddit_fetcher.py
+++ b/tests/test_reddit_fetcher.py
@@ -1,0 +1,71 @@
+"""Tests for Reddit OAuth fetching."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from src.core.config import SearchConfig, SearchException
+from src.core.reddit_fetcher import RedditFetcher
+
+
+@pytest.fixture(autouse=True)
+def reddit_credentials(monkeypatch):
+    monkeypatch.setattr(SearchConfig, "REDDIT_CLIENT_ID", "client-id")
+    monkeypatch.setattr(SearchConfig, "REDDIT_CLIENT_SECRET", "client-secret")
+    monkeypatch.setattr(SearchConfig, "REDDIT_USER_AGENT", "test-agent")
+    monkeypatch.setattr(SearchConfig, "REDDIT_PROXY_URL", None)
+
+
+def response(status: int, payload=None, headers=None, request_url="https://example.test"):
+    request = httpx.Request("GET", request_url)
+    return httpx.Response(status, json=payload, headers=headers, request=request)
+
+
+@pytest.mark.asyncio
+async def test_fetch_uses_oauth_and_caches_token():
+    token_response = response(
+        200,
+        {"access_token": "token-1", "expires_in": 3600},
+        request_url=RedditFetcher.TOKEN_URL,
+    )
+    listing_response = response(200, {"kind": "Listing", "data": {"children": []}})
+    client = AsyncMock()
+    client.post.return_value = token_response
+    client.get.return_value = listing_response
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+
+    with patch("src.core.reddit_fetcher.httpx.AsyncClient", return_value=client):
+        fetcher = RedditFetcher()
+        await fetcher.fetch_subreddit_posts("python")
+        await fetcher.fetch_subreddit_posts("python")
+
+    assert client.post.await_count == 1
+    assert client.get.await_count == 2
+    assert client.get.await_args.kwargs["headers"]["Authorization"] == "bearer token-1"
+    assert client.get.await_args.args[0].startswith("https://oauth.reddit.com/")
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_has_clear_error(monkeypatch):
+    monkeypatch.setattr(SearchConfig, "REDDIT_CLIENT_ID", None)
+    fetcher = RedditFetcher()
+
+    with pytest.raises(SearchException, match="REDDIT_CLIENT_ID"):
+        await fetcher.fetch_subreddit_posts("python")
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_reports_reset_time():
+    fetcher = RedditFetcher()
+    fetcher._get_access_token = AsyncMock(return_value="token")
+    limited = response(429, {}, {"x-ratelimit-reset": "42"})
+    client = AsyncMock()
+    client.get.return_value = limited
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+
+    with patch("src.core.reddit_fetcher.httpx.AsyncClient", return_value=client):
+        with pytest.raises(SearchException, match="42 seconds"):
+            await fetcher.fetch_subreddit_posts("python")


### PR DESCRIPTION
## Summary

- replace blocked unauthenticated `old.reddit.com` JSON calls with Reddit's OAuth Data API
- cache application-only access tokens and refresh once on HTTP 401
- report useful 403 and 429 errors, including Reddit's reset delay when available
- add separate `REDDIT_PROXY_URL` control so Reddit can bypass commercial VPN exits
- document and pass Reddit settings through Docker Compose

## Verification

- `tests/test_reddit_fetcher.py`: 3 passed
- live OAuth token request: succeeded
- live `r/python` listing request: succeeded
- live post/comment-tree request: succeeded
- secret remains only in ignored local `.env` and is absent from the Git diff

The broader unit run produced 91 passes and 1 skip. Eight existing `test_fetch.py`
network tests failed because `httpbin.org` returned HTTP 503 and its Jina fallback
returned HTTP 401; those failures are unrelated to this change.
