### PR TITLE
Add Reddit search and research tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,27 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   - `sort` (optional, default: `confidence`) — confidence, top, new, controversial, old, qa
   - `limit` (optional, default: 100, max: 500) — max comments
   - `depth` (optional) — max reply nesting depth
-  - Returns: post detail with selftext, media URLs, and nested comments
+  - Returns: post detail with selftext, media URLs, flattened comments, and IDs for omitted comments
+
+- **`search_reddit`** — Search public Reddit posts globally or within one subreddit
+  - `query` (required) — search terms
+  - `subreddit` (optional) — restrict results to one subreddit
+  - `sort` (optional, default: `relevance`) — relevance, hot, top, new, comments
+  - `time_filter`, `limit`, and `after` support time filtering and pagination
+
+- **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `redd.it` URL, or post ID
+  - `reference` (required) — any supported Reddit post reference
+  - `sort`, `limit`, and `depth` control returned comments
+  - Returns `more_comment_ids` when Reddit omits parts of the comment tree
+
+- **`fetch_more_comments`** — Expand omitted comment branches
+  - `post_id` (required) — post ID with or without `t3_`
+  - `comment_ids` (required) — up to 100 IDs from `more_comment_ids`
+  - `sort` (optional, default: `confidence`)
+
+- **`fetch_subreddit_info`** — Fetch public community metadata
+  - `subreddit` (required) — subreddit name without `r/`
+  - Returns description, subscriber/activity counts, NSFW/quarantine flags, type, and imagery
 
 ## Quick Start
 
@@ -108,6 +128,9 @@ mcporter call webintel-mcp.search query="AI breakthroughs" categories="science" 
 mcporter call webintel-mcp.search query="open source LLM" categories="news" time_range="day" language="en"
 mcporter call webintel-mcp.fetch_content url="https://example.com"
 mcporter call webintel-mcp.fetch_subreddit subreddit="python" sort="top" time_filter="week"
+mcporter call webintel-mcp.search_reddit query="asyncio patterns" subreddit="python" sort="top" time_filter="year"
+mcporter call webintel-mcp.fetch_reddit_post reference="https://www.reddit.com/r/python/comments/POST_ID/title/"
+mcporter call webintel-mcp.fetch_subreddit_info subreddit="python"
 ```
 
 ## Docker Options

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   - `sort` (optional, default: `relevance`) — relevance, hot, top, new, comments
   - `time_filter`, `limit`, and `after` support time filtering and pagination
 
-- **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `redd.it` URL, or post ID
+- **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `/s/` share URL, `redd.it` URL, or post ID
   - `reference` (required) — any supported Reddit post reference
   - `sort`, `limit`, and `depth` control returned comments
   - Returns `more_comment_ids` when Reddit omits parts of the comment tree

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -3,7 +3,7 @@ Pydantic models for search results and API responses
 """
 
 from typing import List, Optional, Union
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 # Specific data models for different search types
@@ -140,6 +140,11 @@ class RedditPostDetail(BaseModel):
     selftext: Optional[str] = None
     media_urls: List[str] = []  # Extracted media/image URLs
     comments: List[RedditComment] = []
+    id: Optional[str] = None
+    subreddit: Optional[str] = None
+    score: Optional[int] = None
+    permalink: Optional[str] = None
+    more_comment_ids: List[str] = Field(default_factory=list)
 
 
 class SubredditPostsOutput(BaseModel):
@@ -155,4 +160,40 @@ class SubredditPostsOutput(BaseModel):
 class RedditPostOutput(BaseModel):
     """Output model for single Reddit post with comments."""
     post: RedditPostDetail
+    success: bool
+
+
+class RedditSearchOutput(BaseModel):
+    """Output model for Reddit post search."""
+    query: str
+    subreddit: Optional[str] = None
+    sort: str
+    time_filter: Optional[str] = None
+    posts: List[RedditPostSummary]
+    after_cursor: Optional[str] = None
+    success: bool
+
+
+class RedditCommentsOutput(BaseModel):
+    """Output model for an expanded set of Reddit comments."""
+    post_id: str
+    comments: List[RedditComment]
+    more_comment_ids: List[str] = Field(default_factory=list)
+    success: bool
+
+
+class SubredditInfoOutput(BaseModel):
+    """Public metadata describing a subreddit."""
+    display_name: str
+    title: str
+    public_description: str
+    subscribers: Optional[int] = None
+    active_user_count: Optional[int] = None
+    created_utc: Optional[float] = None
+    over18: bool = False
+    quarantined: bool = False
+    subreddit_type: Optional[str] = None
+    url: str
+    icon_img: Optional[str] = None
+    banner_img: Optional[str] = None
     success: bool

--- a/src/core/reddit_fetcher.py
+++ b/src/core/reddit_fetcher.py
@@ -4,7 +4,7 @@ import asyncio
 import re
 import time
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
@@ -76,6 +76,71 @@ class RedditFetcher:
         if not post_id or not cls.POST_ID_PATTERN.fullmatch(post_id):
             raise SearchException("Could not find a valid post ID in the Reddit URL")
         return post_id.lower(), subreddit
+
+    async def resolve_post_reference(self, reference: str) -> tuple[str, Optional[str]]:
+        """Resolve canonical references directly and Reddit share URLs via redirects."""
+        try:
+            return self.parse_post_reference(reference)
+        except SearchException as e:
+            parse_error = e
+
+        share_url = reference.strip()
+        if share_url.startswith("/"):
+            share_url = f"https://www.reddit.com{share_url}"
+        parsed = urlparse(share_url)
+        host = (parsed.hostname or "").lower()
+        parts = [part for part in parsed.path.split("/") if part]
+        is_reddit_host = host == "reddit.com" or host.endswith(".reddit.com")
+        is_share_url = (
+            parsed.scheme in {"http", "https"}
+            and is_reddit_host
+            and len(parts) >= 4
+            and parts[0].lower() == "r"
+            and parts[2].lower() == "s"
+        )
+        if not is_share_url:
+            raise parse_error
+
+        try:
+            async with httpx.AsyncClient(proxy=SearchConfig.REDDIT_PROXY_URL) as client:
+                for _ in range(5):
+                    response = await client.get(
+                        share_url,
+                        headers=self.headers,
+                        follow_redirects=False,
+                        timeout=SearchConfig.FETCH_TIMEOUT,
+                    )
+                    location = response.headers.get("location")
+                    if not response.is_redirect or not location:
+                        response.raise_for_status()
+                        break
+
+                    share_url = urljoin(str(response.url), location)
+                    try:
+                        return self.parse_post_reference(share_url)
+                    except SearchException:
+                        redirect = urlparse(share_url)
+                        redirect_host = (redirect.hostname or "").lower()
+                        if not (
+                            redirect.scheme in {"http", "https"}
+                            and (
+                                redirect_host == "reddit.com"
+                                or redirect_host.endswith(".reddit.com")
+                            )
+                        ):
+                            raise SearchException(
+                                "Reddit share URL redirected outside Reddit"
+                            )
+        except httpx.TimeoutException:
+            raise SearchException("Reddit share URL resolution timed out")
+        except httpx.HTTPStatusError as e:
+            raise SearchException(
+                f"Reddit share URL resolution failed with HTTP {e.response.status_code}"
+            )
+        except httpx.HTTPError as e:
+            raise SearchException(f"Reddit share URL resolution failed: {e}")
+
+        raise SearchException("Reddit share URL did not resolve to a post")
 
     async def _get_access_token(self, force_refresh: bool = False) -> str:
         """Return a cached application-only OAuth token."""

--- a/src/core/reddit_fetcher.py
+++ b/src/core/reddit_fetcher.py
@@ -1,8 +1,10 @@
 """Reddit content fetching using Reddit's OAuth Data API."""
 
 import asyncio
+import re
 import time
 from typing import Optional
+from urllib.parse import urlparse
 
 import httpx
 
@@ -15,6 +17,8 @@ class RedditFetcher:
     BASE_URL = "https://oauth.reddit.com"
     TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
     TOKEN_EXPIRY_MARGIN = 60
+    SUBREDDIT_PATTERN = re.compile(r"^[A-Za-z0-9_]{1,100}$")
+    POST_ID_PATTERN = re.compile(r"^[a-z0-9]{1,12}$", re.IGNORECASE)
     
     def __init__(self):
         self.headers = {
@@ -30,6 +34,48 @@ class RedditFetcher:
                 "Reddit OAuth is not configured. Set REDDIT_CLIENT_ID and "
                 "REDDIT_CLIENT_SECRET."
             )
+
+    @classmethod
+    def _validate_subreddit(cls, subreddit: str) -> str:
+        subreddit = subreddit.removeprefix("r/").strip()
+        if not cls.SUBREDDIT_PATTERN.fullmatch(subreddit):
+            raise SearchException("Invalid subreddit name")
+        return subreddit
+
+    @classmethod
+    def parse_post_reference(cls, reference: str) -> tuple[str, Optional[str]]:
+        """Extract a post ID and optional subreddit from a Reddit URL or ID."""
+        reference = reference.strip()
+        plain_id = reference.removeprefix("t3_")
+        if cls.POST_ID_PATTERN.fullmatch(plain_id):
+            return plain_id.lower(), None
+
+        if reference.startswith("/"):
+            reference = f"https://www.reddit.com{reference}"
+        parsed = urlparse(reference)
+        host = (parsed.hostname or "").lower()
+        is_reddit_host = host == "reddit.com" or host.endswith(".reddit.com")
+        if (
+            parsed.scheme not in {"http", "https"}
+            or (not is_reddit_host and host != "redd.it")
+        ):
+            raise SearchException("Expected a Reddit post URL, redd.it URL, or post ID")
+
+        parts = [part for part in parsed.path.split("/") if part]
+        subreddit = None
+        post_id = None
+        if host == "redd.it" and parts:
+            post_id = parts[0]
+        elif "comments" in parts:
+            comments_index = parts.index("comments")
+            if comments_index + 1 < len(parts):
+                post_id = parts[comments_index + 1]
+            if comments_index >= 2 and parts[comments_index - 2].lower() == "r":
+                subreddit = cls._validate_subreddit(parts[comments_index - 1])
+
+        if not post_id or not cls.POST_ID_PATTERN.fullmatch(post_id):
+            raise SearchException("Could not find a valid post ID in the Reddit URL")
+        return post_id.lower(), subreddit
 
     async def _get_access_token(self, force_refresh: bool = False) -> str:
         """Return a cached application-only OAuth token."""
@@ -137,6 +183,7 @@ class RedditFetcher:
             SearchException: If fetching fails
         """
         # Validate inputs
+        subreddit = self._validate_subreddit(subreddit)
         valid_sorts = ["hot", "new", "top", "rising", "controversial"]
         if sort not in valid_sorts:
             raise SearchException(f"Invalid sort: {sort}. Must be one of {valid_sorts}")
@@ -183,7 +230,7 @@ class RedditFetcher:
     
     async def fetch_post_with_comments(
         self,
-        subreddit: str,
+        subreddit: Optional[str],
         post_id: str,
         sort: str = "confidence",
         limit: int = 100,
@@ -195,7 +242,7 @@ class RedditFetcher:
         Fetch a single post with comments.
         
         Args:
-            subreddit: Subreddit name (without r/ prefix)
+            subreddit: Optional subreddit name (without r/ prefix)
             post_id: Post ID (without t3_ prefix)
             sort: Comment sort (confidence, top, new, controversial, old, qa)
             limit: Max comments to fetch (1-500, default 100)
@@ -210,6 +257,11 @@ class RedditFetcher:
             SearchException: If fetching fails
         """
         # Validate inputs
+        if subreddit:
+            subreddit = self._validate_subreddit(subreddit)
+        post_id = post_id.removeprefix("t3_").lower()
+        if not self.POST_ID_PATTERN.fullmatch(post_id):
+            raise SearchException("Invalid Reddit post ID")
         valid_sorts = ["confidence", "top", "new", "controversial", "old", "qa"]
         if sort not in valid_sorts:
             raise SearchException(f"Invalid sort: {sort}. Must be one of {valid_sorts}")
@@ -223,9 +275,8 @@ class RedditFetcher:
         if context is not None and (context < 0 or context > 8):
             raise SearchException("Context must be between 0 and 8")
         
-        # Build URL - need to get the slug from the post first or use a generic path
-        # Reddit is flexible with the slug, so we can use a placeholder
-        url = f"{self.BASE_URL}/r/{subreddit}/comments/{post_id}.json"
+        path = f"/r/{subreddit}/comments/{post_id}.json" if subreddit else f"/comments/{post_id}.json"
+        url = f"{self.BASE_URL}{path}"
         
         # Build query params
         params = {
@@ -261,3 +312,117 @@ class RedditFetcher:
             raise
         except Exception as e:
             raise SearchException(f"Failed to fetch post: {str(e)}")
+
+    async def search_posts(
+        self,
+        query: str,
+        subreddit: Optional[str] = None,
+        sort: str = "relevance",
+        time_filter: Optional[str] = None,
+        limit: int = 25,
+        after: Optional[str] = None,
+    ) -> dict:
+        """Search public Reddit posts globally or within one subreddit."""
+        query = query.strip()
+        if not query:
+            raise SearchException("Reddit search query cannot be empty")
+        if len(query) > 500:
+            raise SearchException("Reddit search query cannot exceed 500 characters")
+        valid_sorts = ["relevance", "hot", "top", "new", "comments"]
+        if sort not in valid_sorts:
+            raise SearchException(f"Invalid search sort: {sort}. Must be one of {valid_sorts}")
+        valid_time_filters = ["hour", "day", "week", "month", "year", "all"]
+        if time_filter and time_filter not in valid_time_filters:
+            raise SearchException(
+                f"Invalid time filter: {time_filter}. Must be one of {valid_time_filters}"
+            )
+        if limit < 1 or limit > 100:
+            raise SearchException("Limit must be between 1 and 100")
+
+        if subreddit:
+            subreddit = self._validate_subreddit(subreddit)
+            url = f"{self.BASE_URL}/r/{subreddit}/search.json"
+        else:
+            url = f"{self.BASE_URL}/search.json"
+        params = {"q": query, "sort": sort, "limit": limit, "raw_json": 1}
+        if subreddit:
+            params["restrict_sr"] = "on"
+        if time_filter:
+            params["t"] = time_filter
+        if after:
+            params["after"] = after
+
+        try:
+            response = await self._get(url, params)
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 429:
+                raise SearchException(self._rate_limit_message(e.response))
+            raise SearchException(f"Reddit search failed with HTTP {e.response.status_code}")
+        except httpx.TimeoutException:
+            raise SearchException("Reddit search request timed out")
+
+    async def fetch_more_comments(
+        self,
+        post_id: str,
+        comment_ids: list[str],
+        sort: str = "confidence",
+    ) -> dict:
+        """Expand comment IDs returned in a thread's `more` placeholders."""
+        post_id = post_id.removeprefix("t3_").lower()
+        if not self.POST_ID_PATTERN.fullmatch(post_id):
+            raise SearchException("Invalid Reddit post ID")
+        if not comment_ids or len(comment_ids) > 100:
+            raise SearchException("comment_ids must contain between 1 and 100 IDs")
+        clean_ids = []
+        for comment_id in comment_ids:
+            clean_id = comment_id.removeprefix("t1_").lower()
+            if not self.POST_ID_PATTERN.fullmatch(clean_id):
+                raise SearchException(f"Invalid Reddit comment ID: {comment_id}")
+            if clean_id not in clean_ids:
+                clean_ids.append(clean_id)
+        valid_sorts = ["confidence", "top", "new", "controversial", "old", "qa"]
+        if sort not in valid_sorts:
+            raise SearchException(f"Invalid comment sort: {sort}. Must be one of {valid_sorts}")
+
+        params = {
+            "api_type": "json",
+            "link_id": f"t3_{post_id}",
+            "children": ",".join(clean_ids),
+            "sort": sort,
+            "limit_children": "false",
+            "raw_json": 1,
+        }
+        try:
+            response = await self._get(f"{self.BASE_URL}/api/morechildren", params)
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 429:
+                raise SearchException(self._rate_limit_message(e.response))
+            raise SearchException(
+                f"Reddit comment expansion failed with HTTP {e.response.status_code}"
+            )
+        except httpx.TimeoutException:
+            raise SearchException("Reddit comment expansion timed out")
+
+    async def fetch_subreddit_info(self, subreddit: str) -> dict:
+        """Fetch public metadata for a subreddit."""
+        subreddit = self._validate_subreddit(subreddit)
+        try:
+            response = await self._get(
+                f"{self.BASE_URL}/r/{subreddit}/about.json",
+                {"raw_json": 1},
+            )
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise SearchException(f"Subreddit not found: r/{subreddit}")
+            if e.response.status_code == 403:
+                raise SearchException(f"Reddit denied access to r/{subreddit}")
+            if e.response.status_code == 429:
+                raise SearchException(self._rate_limit_message(e.response))
+            raise SearchException(
+                f"Subreddit metadata request failed with HTTP {e.response.status_code}"
+            )
+        except httpx.TimeoutException:
+            raise SearchException("Subreddit metadata request timed out")

--- a/src/server/handlers.py
+++ b/src/server/handlers.py
@@ -18,7 +18,10 @@ from ..core.models import (
     RedditComment,
     RedditPostDetail,
     SubredditPostsOutput,
-    RedditPostOutput
+    RedditPostOutput,
+    RedditSearchOutput,
+    RedditCommentsOutput,
+    SubredditInfoOutput,
 )
 
 
@@ -257,6 +260,23 @@ class SearchHandlers:
                 comments.extend(replies)
         
         return comments
+
+    def _collect_more_comment_ids(self, children: List[Dict]) -> List[str]:
+        """Collect expandable comment IDs from nested Reddit `more` objects."""
+        comment_ids = []
+        for child in children:
+            if child.get("kind") == "more":
+                for comment_id in child.get("data", {}).get("children", []):
+                    if comment_id and comment_id not in comment_ids:
+                        comment_ids.append(comment_id)
+                continue
+            replies = child.get("data", {}).get("replies")
+            if isinstance(replies, dict):
+                nested = replies.get("data", {}).get("children", [])
+                for comment_id in self._collect_more_comment_ids(nested):
+                    if comment_id not in comment_ids:
+                        comment_ids.append(comment_id)
+        return comment_ids
     
     def _extract_media_urls(self, post_data: Dict[str, Any]) -> List[str]:
         """Extract media URLs from Reddit post data."""
@@ -396,7 +416,12 @@ class SearchHandlers:
                 is_self=post_data.get("is_self", False),
                 selftext=post_data.get("selftext") if post_data.get("selftext") else None,
                 media_urls=media_urls,
-                comments=comments
+                comments=comments,
+                id=post_data.get("id"),
+                subreddit=post_data.get("subreddit"),
+                score=post_data.get("score", 0),
+                permalink=post_data.get("permalink"),
+                more_comment_ids=self._collect_more_comment_ids(comments_listing),
             )
             
             return RedditPostOutput(
@@ -405,5 +430,114 @@ class SearchHandlers:
             )
         except SearchException as e:
             raise ToolError(f"Failed to fetch Reddit post: {str(e)}")
+        except Exception as e:
+            raise ToolError(f"Unexpected error: {str(e)}")
+
+    async def search_reddit(
+        self,
+        query: str,
+        subreddit: str = None,
+        sort: str = "relevance",
+        time_filter: str = None,
+        limit: int = 25,
+        after: str = None,
+    ) -> RedditSearchOutput:
+        """Search Reddit posts globally or within a subreddit."""
+        try:
+            response = await self.reddit_fetcher.search_posts(
+                query=query,
+                subreddit=subreddit,
+                sort=sort,
+                time_filter=time_filter,
+                limit=limit,
+                after=after,
+            )
+            data = response.get("data", {})
+            posts = [
+                self._parse_reddit_post_summary(child.get("data", {}))
+                for child in data.get("children", [])
+                if child.get("kind") == "t3"
+            ]
+            return RedditSearchOutput(
+                query=query,
+                subreddit=subreddit,
+                sort=sort,
+                time_filter=time_filter,
+                posts=posts,
+                after_cursor=data.get("after"),
+                success=True,
+            )
+        except SearchException as e:
+            raise ToolError(f"Failed to search Reddit: {str(e)}")
+        except Exception as e:
+            raise ToolError(f"Unexpected error: {str(e)}")
+
+    async def fetch_reddit_post(
+        self,
+        reference: str,
+        sort: str = "confidence",
+        limit: int = 100,
+        depth: int = None,
+    ) -> RedditPostOutput:
+        """Fetch a post from its URL, permalink, redd.it URL, or post ID."""
+        try:
+            post_id, subreddit = self.reddit_fetcher.parse_post_reference(reference)
+        except SearchException as e:
+            raise ToolError(f"Invalid Reddit post reference: {str(e)}")
+        return await self.fetch_subreddit_post(
+            subreddit=subreddit,
+            post_id=post_id,
+            sort=sort,
+            limit=limit,
+            depth=depth,
+        )
+
+    async def fetch_more_comments(
+        self,
+        post_id: str,
+        comment_ids: List[str],
+        sort: str = "confidence",
+    ) -> RedditCommentsOutput:
+        """Expand comment IDs from a post's `more_comment_ids` field."""
+        try:
+            response = await self.reddit_fetcher.fetch_more_comments(
+                post_id=post_id,
+                comment_ids=comment_ids,
+                sort=sort,
+            )
+            things = response.get("json", {}).get("data", {}).get("things", [])
+            return RedditCommentsOutput(
+                post_id=post_id.removeprefix("t3_"),
+                comments=self._parse_reddit_comments(things),
+                more_comment_ids=self._collect_more_comment_ids(things),
+                success=True,
+            )
+        except SearchException as e:
+            raise ToolError(f"Failed to expand Reddit comments: {str(e)}")
+        except Exception as e:
+            raise ToolError(f"Unexpected error: {str(e)}")
+
+    async def fetch_subreddit_info(self, subreddit: str) -> SubredditInfoOutput:
+        """Fetch public metadata describing a subreddit."""
+        try:
+            response = await self.reddit_fetcher.fetch_subreddit_info(subreddit)
+            data = response.get("data", {})
+            return SubredditInfoOutput(
+                display_name=data.get("display_name", subreddit),
+                title=data.get("title", ""),
+                public_description=data.get("public_description", ""),
+                subscribers=data.get("subscribers"),
+                active_user_count=data.get("active_user_count"),
+                created_utc=data.get("created_utc"),
+                over18=data.get("over18", False),
+                quarantined=data.get("quarantine", False),
+                subreddit_type=data.get("subreddit_type"),
+                url=data.get("url", f"/r/{subreddit}/"),
+                icon_img=data.get("icon_img") or None,
+                banner_img=data.get("banner_img") or None,
+                success=True,
+            )
+        except SearchException as e:
+            raise ToolError(f"Failed to fetch subreddit info: {str(e)}")
         except Exception as e:
             raise ToolError(f"Unexpected error: {str(e)}")

--- a/src/server/handlers.py
+++ b/src/server/handlers.py
@@ -245,7 +245,7 @@ class SearchHandlers:
                 body=comment_data.get("body", ""),
                 parent_id=parent_id,
                 created_utc=comment_data.get("created_utc", 0),
-                depth=depth
+                depth=comment_data.get("depth", depth),
             )
             comments.append(comment)
             
@@ -481,7 +481,9 @@ class SearchHandlers:
     ) -> RedditPostOutput:
         """Fetch a post from its URL, permalink, redd.it URL, or post ID."""
         try:
-            post_id, subreddit = self.reddit_fetcher.parse_post_reference(reference)
+            post_id, subreddit = await self.reddit_fetcher.resolve_post_reference(
+                reference
+            )
         except SearchException as e:
             raise ToolError(f"Invalid Reddit post reference: {str(e)}")
         return await self.fetch_subreddit_post(

--- a/src/server/mcp_server.py
+++ b/src/server/mcp_server.py
@@ -16,7 +16,10 @@ from ..core.models import (
     FetchContentOutput, 
     YouTubeContentOutput,
     SubredditPostsOutput,
-    RedditPostOutput
+    RedditPostOutput,
+    RedditSearchOutput,
+    RedditCommentsOutput,
+    SubredditInfoOutput,
 )
 
 
@@ -255,6 +258,144 @@ async def fetch_subreddit_post(
         limit=limit,
         depth=depth
     )
+
+
+@mcp.tool(
+    name="search_reddit",
+    tags={"reddit", "search", "posts"},
+    annotations={
+        "title": "Search Reddit Posts",
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+)
+async def search_reddit(
+    query: Annotated[str, Field(
+        description="Search query",
+        min_length=1,
+        max_length=500,
+    )],
+    subreddit: Annotated[Optional[str], Field(
+        description="Optional subreddit name; omit to search all of Reddit",
+        max_length=100,
+    )] = None,
+    sort: Annotated[str, Field(
+        description="Sort: relevance, hot, top, new, or comments",
+    )] = "relevance",
+    time_filter: Annotated[Optional[str], Field(
+        description="Time filter: hour, day, week, month, year, or all",
+    )] = None,
+    limit: Annotated[int, Field(
+        description="Number of posts to return",
+        ge=1,
+        le=100,
+    )] = 25,
+    after: Annotated[Optional[str], Field(
+        description="Pagination cursor from a previous search",
+    )] = None,
+) -> RedditSearchOutput:
+    """Search public Reddit posts globally or within one subreddit."""
+    return await handlers.search_reddit(
+        query=query,
+        subreddit=subreddit,
+        sort=sort,
+        time_filter=time_filter,
+        limit=limit,
+        after=after,
+    )
+
+
+@mcp.tool(
+    name="fetch_reddit_post",
+    tags={"reddit", "post", "comments", "url"},
+    annotations={
+        "title": "Fetch Reddit Post by URL or ID",
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+)
+async def fetch_reddit_post(
+    reference: Annotated[str, Field(
+        description="Reddit post URL, permalink, redd.it URL, or post ID",
+        min_length=1,
+        max_length=500,
+    )],
+    sort: Annotated[str, Field(
+        description="Comment sort: confidence, top, new, controversial, old, or qa",
+    )] = "confidence",
+    limit: Annotated[int, Field(
+        description="Maximum comments to fetch",
+        ge=1,
+        le=500,
+    )] = 100,
+    depth: Annotated[Optional[int], Field(
+        description="Maximum reply nesting depth",
+        ge=1,
+    )] = None,
+) -> RedditPostOutput:
+    """Fetch a Reddit post and comments from a URL, permalink, or post ID."""
+    return await handlers.fetch_reddit_post(
+        reference=reference,
+        sort=sort,
+        limit=limit,
+        depth=depth,
+    )
+
+
+@mcp.tool(
+    name="fetch_more_comments",
+    tags={"reddit", "comments", "thread"},
+    annotations={
+        "title": "Expand Reddit Comments",
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+)
+async def fetch_more_comments(
+    post_id: Annotated[str, Field(
+        description="Reddit post ID, with or without the t3_ prefix",
+        min_length=1,
+        max_length=20,
+    )],
+    comment_ids: Annotated[List[str], Field(
+        description="Comment IDs from a post's more_comment_ids field",
+        min_length=1,
+        max_length=100,
+    )],
+    sort: Annotated[str, Field(
+        description="Comment sort: confidence, top, new, controversial, old, or qa",
+    )] = "confidence",
+) -> RedditCommentsOutput:
+    """Expand omitted comments using IDs returned by a post fetch."""
+    return await handlers.fetch_more_comments(
+        post_id=post_id,
+        comment_ids=comment_ids,
+        sort=sort,
+    )
+
+
+@mcp.tool(
+    name="fetch_subreddit_info",
+    tags={"reddit", "subreddit", "metadata"},
+    annotations={
+        "title": "Fetch Subreddit Information",
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+)
+async def fetch_subreddit_info(
+    subreddit: Annotated[str, Field(
+        description="Subreddit name without the r/ prefix",
+        min_length=1,
+        max_length=100,
+    )],
+) -> SubredditInfoOutput:
+    """Fetch public metadata for a subreddit."""
+    return await handlers.fetch_subreddit_info(subreddit)
 
 
 def resolve_transport(cli_http=False, cli_sse=False, env_transport=None):

--- a/src/server/mcp_server.py
+++ b/src/server/mcp_server.py
@@ -318,7 +318,7 @@ async def search_reddit(
 )
 async def fetch_reddit_post(
     reference: Annotated[str, Field(
-        description="Reddit post URL, permalink, redd.it URL, or post ID",
+        description="Reddit post URL, /s/ share URL, permalink, redd.it URL, or post ID",
         min_length=1,
         max_length=500,
     )],
@@ -335,7 +335,7 @@ async def fetch_reddit_post(
         ge=1,
     )] = None,
 ) -> RedditPostOutput:
-    """Fetch a Reddit post and comments from a URL, permalink, or post ID."""
+    """Fetch a Reddit post and comments from a URL, share URL, permalink, or post ID."""
     return await handlers.fetch_reddit_post(
         reference=reference,
         sort=sort,

--- a/tests/test_comment_recursion.py
+++ b/tests/test_comment_recursion.py
@@ -192,3 +192,33 @@ class TestCommentRecursionDepth:
         ]
 
         assert self.handlers._collect_more_comment_ids(children) == ["abc", "def", "ghi"]
+
+    def test_uses_reddit_depth_for_flat_expanded_comments(self):
+        children = [
+            {
+                "kind": "t1",
+                "data": {
+                    "id": "parent",
+                    "author": "user1",
+                    "body": "Parent",
+                    "parent_id": "t1_outside",
+                    "created_utc": 1,
+                    "depth": 4,
+                },
+            },
+            {
+                "kind": "t1",
+                "data": {
+                    "id": "child",
+                    "author": "user2",
+                    "body": "Child",
+                    "parent_id": "t1_parent",
+                    "created_utc": 2,
+                    "depth": 5,
+                },
+            },
+        ]
+
+        comments = self.handlers._parse_reddit_comments(children)
+
+        assert [comment.depth for comment in comments] == [4, 5]

--- a/tests/test_comment_recursion.py
+++ b/tests/test_comment_recursion.py
@@ -173,3 +173,22 @@ class TestCommentRecursionDepth:
             d = c.model_dump()
             assert "depth" in d
             assert "replies" not in d
+
+    def test_collects_nested_more_comment_ids(self):
+        children = [
+            {
+                "kind": "t1",
+                "data": {
+                    "replies": {
+                        "data": {
+                            "children": [
+                                {"kind": "more", "data": {"children": ["abc", "def"]}}
+                            ]
+                        }
+                    }
+                },
+            },
+            {"kind": "more", "data": {"children": ["def", "ghi"]}},
+        ]
+
+        assert self.handlers._collect_more_comment_ids(children) == ["abc", "def", "ghi"]

--- a/tests/test_reddit_fetcher.py
+++ b/tests/test_reddit_fetcher.py
@@ -96,6 +96,48 @@ def test_parse_post_reference_rejects_non_reddit_url():
 
 
 @pytest.mark.asyncio
+async def test_resolve_post_reference_follows_reddit_share_redirect():
+    fetcher = RedditFetcher()
+    share_url = "https://www.reddit.com/r/python/s/share123"
+    redirect = response(
+        302,
+        headers={
+            "location": "https://www.reddit.com/r/python/comments/1abcde/example_title/"
+        },
+        request_url=share_url,
+    )
+    client = AsyncMock()
+    client.get.return_value = redirect
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+
+    with patch("src.core.reddit_fetcher.httpx.AsyncClient", return_value=client):
+        result = await fetcher.resolve_post_reference(share_url)
+
+    assert result == ("1abcde", "python")
+    assert client.get.await_args.kwargs["follow_redirects"] is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_post_reference_rejects_external_share_redirect():
+    fetcher = RedditFetcher()
+    share_url = "https://www.reddit.com/r/python/s/share123"
+    redirect = response(
+        302,
+        headers={"location": "https://example.com/r/python/comments/1abcde/title/"},
+        request_url=share_url,
+    )
+    client = AsyncMock()
+    client.get.return_value = redirect
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+
+    with patch("src.core.reddit_fetcher.httpx.AsyncClient", return_value=client):
+        with pytest.raises(SearchException, match="outside Reddit"):
+            await fetcher.resolve_post_reference(share_url)
+
+
+@pytest.mark.asyncio
 async def test_search_posts_scopes_to_subreddit():
     fetcher = RedditFetcher()
     fetcher._get = AsyncMock(return_value=response(200, {"kind": "Listing"}))

--- a/tests/test_reddit_fetcher.py
+++ b/tests/test_reddit_fetcher.py
@@ -69,3 +69,71 @@ async def test_rate_limit_reports_reset_time():
     with patch("src.core.reddit_fetcher.httpx.AsyncClient", return_value=client):
         with pytest.raises(SearchException, match="42 seconds"):
             await fetcher.fetch_subreddit_posts("python")
+
+
+@pytest.mark.parametrize(
+    ("reference", "post_id", "subreddit"),
+    [
+        ("1abcde", "1abcde", None),
+        ("t3_1abcde", "1abcde", None),
+        ("https://redd.it/1abcde", "1abcde", None),
+        (
+            "https://www.reddit.com/r/python/comments/1abcde/example_title/",
+            "1abcde",
+            "python",
+        ),
+        ("/r/python/comments/1abcde/example_title/", "1abcde", "python"),
+        ("https://www.reddit.com/comments/a/old_post/", "a", None),
+    ],
+)
+def test_parse_post_reference(reference, post_id, subreddit):
+    assert RedditFetcher.parse_post_reference(reference) == (post_id, subreddit)
+
+
+def test_parse_post_reference_rejects_non_reddit_url():
+    with pytest.raises(SearchException, match="Reddit post URL"):
+        RedditFetcher.parse_post_reference("https://example.com/comments/1abcde")
+
+
+@pytest.mark.asyncio
+async def test_search_posts_scopes_to_subreddit():
+    fetcher = RedditFetcher()
+    fetcher._get = AsyncMock(return_value=response(200, {"kind": "Listing"}))
+
+    result = await fetcher.search_posts(
+        "asyncio",
+        subreddit="python",
+        sort="top",
+        time_filter="week",
+        limit=10,
+    )
+
+    assert result["kind"] == "Listing"
+    url, params = fetcher._get.await_args.args
+    assert url == "https://oauth.reddit.com/r/python/search.json"
+    assert params["restrict_sr"] == "on"
+    assert params["q"] == "asyncio"
+    assert params["t"] == "week"
+
+
+@pytest.mark.asyncio
+async def test_fetch_more_comments_builds_morechildren_request():
+    fetcher = RedditFetcher()
+    fetcher._get = AsyncMock(return_value=response(200, {"json": {"data": {"things": []}}}))
+
+    await fetcher.fetch_more_comments("t3_1abcde", ["t1_def456", "ghi789"])
+
+    url, params = fetcher._get.await_args.args
+    assert url == "https://oauth.reddit.com/api/morechildren"
+    assert params["link_id"] == "t3_1abcde"
+    assert params["children"] == "def456,ghi789"
+
+
+@pytest.mark.asyncio
+async def test_fetch_subreddit_info_uses_about_endpoint():
+    fetcher = RedditFetcher()
+    fetcher._get = AsyncMock(return_value=response(200, {"kind": "t5", "data": {}}))
+
+    await fetcher.fetch_subreddit_info("python")
+
+    assert fetcher._get.await_args.args[0] == "https://oauth.reddit.com/r/python/about.json"


### PR DESCRIPTION
## Summary

Adds the first batch of Reddit research tools on top of #14:

- `search_reddit` searches globally or within one subreddit with sorting, time filters, and pagination
- `fetch_reddit_post` accepts a Reddit URL, relative permalink, `redd.it` URL, or bare post ID
- `fetch_more_comments` expands up to 100 IDs from Reddit `more` placeholders
- `fetch_subreddit_info` returns public community metadata

Post responses now include the post ID, subreddit, score, permalink, and
`more_comment_ids`, allowing agents to feed omitted IDs directly into
`fetch_more_comments`. The existing `fetch_subreddit_post` tool remains supported.

## Verification

- Python 3.11 tests: 86 passed, 1 skipped
- live scoped Reddit search: succeeded
- live subreddit metadata request: succeeded
- live URL-aware post and comment request: succeeded
- live comment expansion: 5 requested IDs produced 25 comment objects and zero API errors
- Reddit credentials remain only in ignored local `.env` and are absent from the Git diff

## Stack

This PR intentionally targets `fix/reddit-oauth` and depends on #14. After #14 is
merged, this PR can be rebased or its base can be changed to `main`.
