### PR TITLE
Document JSON inputs and outputs for all tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,65 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   </tr>
   </table>
 
+- **`search_reddit`** — Search public Reddit posts globally or within one subreddit
+
+  <table>
+  <tr>
+  <td>
+  <details>
+  <summary>Input</summary>
+
+  ```json
+  {
+    "query": "asyncio patterns",
+    "subreddit": "python",
+    "sort": "top",
+    "time_filter": "year",
+    "limit": 10,
+    "after": null
+  }
+  ```
+
+  </details>
+  </td>
+  <td>
+  <details>
+  <summary>Output</summary>
+
+  ```json
+  {
+    "query": "asyncio patterns",
+    "subreddit": "python",
+    "sort": "top",
+    "time_filter": "year",
+    "posts": [
+      {
+        "id": "1abcde",
+        "title": "Structured concurrency patterns for asyncio",
+        "author": "example_user",
+        "subreddit": "python",
+        "score": 321,
+        "num_comments": 42,
+        "created_utc": 1784044800.0,
+        "url": "https://www.reddit.com/r/python/comments/1abcde/example/",
+        "permalink": "/r/python/comments/1abcde/example/",
+        "is_self": true,
+        "selftext": "A discussion of task groups and cancellation.",
+        "thumbnail": null,
+        "link_flair_text": "Discussion"
+      }
+    ],
+    "after_cursor": null,
+    "success": true
+  }
+  ```
+
+  </details>
+
+  </td>
+  </tr>
+  </table>
+
 ### Content Fetching
 
 - **`fetch_content`** — Fetch and extract readable content from any URL
@@ -165,8 +224,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   </td>
   </tr>
   </table>
-
-### Reddit
 
 - **`fetch_subreddit`** — Browse subreddit posts
 
@@ -276,65 +333,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
       "permalink": "/r/python/comments/1abcde/example/",
       "more_comment_ids": ["ghi789", "jkl012"]
     },
-    "success": true
-  }
-  ```
-
-  </details>
-
-  </td>
-  </tr>
-  </table>
-
-- **`search_reddit`** — Search public Reddit posts globally or within one subreddit
-
-  <table>
-  <tr>
-  <td>
-  <details>
-  <summary>Input</summary>
-
-  ```json
-  {
-    "query": "asyncio patterns",
-    "subreddit": "python",
-    "sort": "top",
-    "time_filter": "year",
-    "limit": 10,
-    "after": null
-  }
-  ```
-
-  </details>
-  </td>
-  <td>
-  <details>
-  <summary>Output</summary>
-
-  ```json
-  {
-    "query": "asyncio patterns",
-    "subreddit": "python",
-    "sort": "top",
-    "time_filter": "year",
-    "posts": [
-      {
-        "id": "1abcde",
-        "title": "Structured concurrency patterns for asyncio",
-        "author": "example_user",
-        "subreddit": "python",
-        "score": 321,
-        "num_comments": 42,
-        "created_utc": 1784044800.0,
-        "url": "https://www.reddit.com/r/python/comments/1abcde/example/",
-        "permalink": "/r/python/comments/1abcde/example/",
-        "is_self": true,
-        "selftext": "A discussion of task groups and cancellation.",
-        "thumbnail": null,
-        "link_flair_text": "Discussion"
-      }
-    ],
-    "after_cursor": null,
     "success": true
   }
   ```

--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 ### Search
 
 - **`search`** — Web search via SearxNG
-  - `query` (required) — search terms
-  - `max_results` (optional, default: 10, max: 25)
-  - `categories` (optional) — comma-separated: `general`, `news`, `science`, `it`, `music`
-  - `time_range` (optional) — `day`, `month`, or `year`
-  - `language` (optional) — ISO language code (e.g., `en`, `de`, `fr`)
-  - Returns: title, url, content snippet, score
 
   Input:
 
@@ -44,9 +38,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`search_videos`** — YouTube video search
-  - `query` (required) — video search terms
-  - `max_results` (optional, default: 10, max: 20)
-  - Returns: url, title, author, content summary, length
 
   Input:
 
@@ -74,10 +65,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 ### Content Fetching
 
 - **`fetch_content`** — Fetch and extract readable content from any URL
-  - `url` (required) — URL to fetch
-  - `offset` (optional, default: 0) — pagination offset
-  - Automatic fallback chain: static fetch → JS rendering (if empty) → Jina Reader (if still empty/error)
-  - Content is returned in 30K character chunks. Use `next_offset` from the response to paginate.
 
   Input:
 
@@ -103,9 +90,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`fetch_youtube_content`** — Download and transcribe YouTube video audio
-  - `video_id` (required) — video ID or full URL (e.g. `dQw4w9WgXcQ` or `https://www.youtube.com/watch?v=dQw4w9WgXcQ`)
-  - Returns: video_id, transcript, transcript_length
-  - Requires: STT endpoint (see [Configuration](#configuration))
 
   Input:
 
@@ -129,12 +113,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 ### Reddit
 
 - **`fetch_subreddit`** — Browse subreddit posts
-  - `subreddit` (required) — subreddit name without `r/` prefix
-  - `sort` (optional, default: `hot`) — hot, new, top, rising, controversial
-  - `time_filter` (optional) — hour, day, week, month, year, all (for top/controversial)
-  - `limit` (optional, default: 25, max: 100)
-  - `after` (optional) — pagination cursor from previous response
-  - Returns: post summaries with title, author, score, comment count, url
 
   Input:
 
@@ -178,12 +156,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`fetch_subreddit_post`** — Fetch a post with full comment tree
-  - `subreddit` (required) — subreddit name without `r/` prefix
-  - `post_id` (required) — post ID without `t3_` prefix
-  - `sort` (optional, default: `confidence`) — confidence, top, new, controversial, old, qa
-  - `limit` (optional, default: 100, max: 500) — max comments
-  - `depth` (optional) — max reply nesting depth
-  - Returns: post detail with selftext, media URLs, flattened comments, and IDs for omitted comments
 
   Input:
 
@@ -231,10 +203,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`search_reddit`** — Search public Reddit posts globally or within one subreddit
-  - `query` (required) — search terms
-  - `subreddit` (optional) — restrict results to one subreddit
-  - `sort` (optional, default: `relevance`) — relevance, hot, top, new, comments
-  - `time_filter`, `limit`, and `after` support time filtering and pagination
 
   Input:
 
@@ -280,9 +248,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `/s/` share URL, `redd.it` URL, or post ID
-  - `reference` (required) — any supported Reddit post reference
-  - `sort`, `limit`, and `depth` control returned comments
-  - Returns `more_comment_ids` when Reddit omits parts of the comment tree
 
   Input:
 
@@ -329,9 +294,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`fetch_more_comments`** — Expand omitted comment branches
-  - `post_id` (required) — post ID with or without `t3_`
-  - `comment_ids` (required) — up to 100 IDs from `more_comment_ids`
-  - `sort` (optional, default: `confidence`)
 
   Input:
 
@@ -364,8 +326,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`fetch_subreddit_info`** — Fetch public community metadata
-  - `subreddit` (required) — subreddit name without `r/`
-  - Returns description, subscriber/activity counts, NSFW/quarantine flags, type, and imagery
 
   Input:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
 - **`search`** — Web search via SearxNG
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -24,7 +25,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   [
@@ -37,9 +41,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ]
   ```
 
+  </details>
+
 - **`search_videos`** — YouTube video search
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -48,7 +55,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   [
@@ -62,11 +72,14 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ]
   ```
 
+  </details>
+
 ### Content Fetching
 
 - **`fetch_content`** — Fetch and extract readable content from any URL
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -75,7 +88,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -89,9 +105,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 - **`fetch_youtube_content`** — Download and transcribe YouTube video audio
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -99,7 +118,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -110,11 +132,14 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 ### Reddit
 
 - **`fetch_subreddit`** — Browse subreddit posts
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -126,7 +151,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -155,9 +183,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 - **`fetch_subreddit_post`** — Fetch a post with full comment tree
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -169,7 +200,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -202,9 +236,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 - **`search_reddit`** — Search public Reddit posts globally or within one subreddit
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -217,7 +254,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -247,9 +287,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 - **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `/s/` share URL, `redd.it` URL, or post ID
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -260,7 +303,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -293,9 +339,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 - **`fetch_more_comments`** — Expand omitted comment branches
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -305,7 +354,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -325,9 +377,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 - **`fetch_subreddit_info`** — Fetch public community metadata
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -335,7 +390,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -354,6 +412,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
     "success": true
   }
   ```
+
+  </details>
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
 - **`search`** — Web search via SearxNG
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -26,7 +29,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -43,8 +47,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`search_videos`** — YouTube video search
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -56,7 +67,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -74,10 +86,17 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 ### Content Fetching
 
 - **`fetch_content`** — Fetch and extract readable content from any URL
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -89,7 +108,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -107,8 +127,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`fetch_youtube_content`** — Download and transcribe YouTube video audio
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -119,7 +146,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -134,10 +162,17 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 ### Reddit
 
 - **`fetch_subreddit`** — Browse subreddit posts
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -152,7 +187,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -185,8 +221,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`fetch_subreddit_post`** — Fetch a post with full comment tree
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -201,7 +244,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -238,8 +282,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`search_reddit`** — Search public Reddit posts globally or within one subreddit
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -255,7 +306,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -289,8 +341,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `/s/` share URL, `redd.it` URL, or post ID
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -304,7 +363,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -341,8 +401,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`fetch_more_comments`** — Expand omitted comment branches
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -355,7 +422,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -379,8 +447,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`fetch_subreddit_info`** — Fetch public community metadata
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -391,7 +466,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -414,6 +490,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
+
+  </td>
+  </tr>
+  </table>
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,58 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   - `language` (optional) — ISO language code (e.g., `en`, `de`, `fr`)
   - Returns: title, url, content snippet, score
 
+  Input:
+
+  ```json
+  {
+    "query": "Python 3.14 release highlights",
+    "max_results": 2,
+    "categories": "it,news",
+    "time_range": "month",
+    "language": "en"
+  }
+  ```
+
+  Output:
+
+  ```json
+  [
+    {
+      "title": "What's New In Python 3.14",
+      "url": "https://docs.python.org/3.14/whatsnew/3.14.html",
+      "content": "Python 3.14 adds new syntax, runtime improvements, and tooling updates.",
+      "score": 1.0
+    }
+  ]
+  ```
+
 - **`search_videos`** — YouTube video search
   - `query` (required) — video search terms
   - `max_results` (optional, default: 10, max: 20)
   - Returns: url, title, author, content summary, length
+
+  Input:
+
+  ```json
+  {
+    "query": "asyncio tutorial",
+    "max_results": 2
+  }
+  ```
+
+  Output:
+
+  ```json
+  [
+    {
+      "url": "https://www.youtube.com/watch?v=example123",
+      "title": "Python Asyncio Explained",
+      "author": "Example Developer",
+      "content": "A practical introduction to async and await in Python.",
+      "length": "12:34"
+    }
+  ]
+  ```
 
 ### Content Fetching
 
@@ -31,10 +79,52 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   - Automatic fallback chain: static fetch → JS rendering (if empty) → Jina Reader (if still empty/error)
   - Content is returned in 30K character chunks. Use `next_offset` from the response to paginate.
 
+  Input:
+
+  ```json
+  {
+    "url": "https://example.com/long-article",
+    "offset": 0
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "content": "Example Domain\n\nThis domain is for use in illustrative examples...",
+    "content_length": 66,
+    "is_truncated": false,
+    "offset": 0,
+    "next_offset": null,
+    "total_length": 66,
+    "success": true
+  }
+  ```
+
 - **`fetch_youtube_content`** — Download and transcribe YouTube video audio
   - `video_id` (required) — video ID or full URL (e.g. `dQw4w9WgXcQ` or `https://www.youtube.com/watch?v=dQw4w9WgXcQ`)
   - Returns: video_id, transcript, transcript_length
   - Requires: STT endpoint (see [Configuration](#configuration))
+
+  Input:
+
+  ```json
+  {
+    "video_id": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "video_id": "dQw4w9WgXcQ",
+    "transcript": "We're no strangers to love...",
+    "transcript_length": 33,
+    "success": true
+  }
+  ```
 
 ### Reddit
 
@@ -46,6 +136,47 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   - `after` (optional) — pagination cursor from previous response
   - Returns: post summaries with title, author, score, comment count, url
 
+  Input:
+
+  ```json
+  {
+    "subreddit": "python",
+    "sort": "top",
+    "time_filter": "week",
+    "limit": 2,
+    "after": null
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "subreddit": "python",
+    "sort": "top",
+    "time_filter": "week",
+    "posts": [
+      {
+        "id": "1abcde",
+        "title": "A useful Python project",
+        "author": "example_user",
+        "subreddit": "python",
+        "score": 142,
+        "num_comments": 27,
+        "created_utc": 1784044800.0,
+        "url": "https://example.com/python-project",
+        "permalink": "/r/python/comments/1abcde/a_useful_python_project/",
+        "is_self": false,
+        "selftext": null,
+        "thumbnail": "https://example.com/thumbnail.jpg",
+        "link_flair_text": "Resource"
+      }
+    ],
+    "after_cursor": "t3_1abcde",
+    "success": true
+  }
+  ```
+
 - **`fetch_subreddit_post`** — Fetch a post with full comment tree
   - `subreddit` (required) — subreddit name without `r/` prefix
   - `post_id` (required) — post ID without `t3_` prefix
@@ -54,25 +185,215 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   - `depth` (optional) — max reply nesting depth
   - Returns: post detail with selftext, media URLs, flattened comments, and IDs for omitted comments
 
+  Input:
+
+  ```json
+  {
+    "subreddit": "python",
+    "post_id": "1abcde",
+    "sort": "confidence",
+    "limit": 100,
+    "depth": 5
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "post": {
+      "title": "What are your favorite asyncio patterns?",
+      "author": "example_user",
+      "num_comments": 48,
+      "created_utc": 1784044800.0,
+      "url": "https://www.reddit.com/r/python/comments/1abcde/example/",
+      "is_self": true,
+      "selftext": "Share the patterns that have worked well for you.",
+      "media_urls": [],
+      "comments": [
+        {
+          "id": "def456",
+          "author": "commenter",
+          "body": "Task groups make cancellation much easier to reason about.",
+          "parent_id": "t3_1abcde",
+          "created_utc": 1784048400.0,
+          "depth": 0
+        }
+      ],
+      "id": "1abcde",
+      "subreddit": "python",
+      "score": 215,
+      "permalink": "/r/python/comments/1abcde/example/",
+      "more_comment_ids": ["ghi789", "jkl012"]
+    },
+    "success": true
+  }
+  ```
+
 - **`search_reddit`** — Search public Reddit posts globally or within one subreddit
   - `query` (required) — search terms
   - `subreddit` (optional) — restrict results to one subreddit
   - `sort` (optional, default: `relevance`) — relevance, hot, top, new, comments
   - `time_filter`, `limit`, and `after` support time filtering and pagination
 
+  Input:
+
+  ```json
+  {
+    "query": "asyncio patterns",
+    "subreddit": "python",
+    "sort": "top",
+    "time_filter": "year",
+    "limit": 10,
+    "after": null
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "query": "asyncio patterns",
+    "subreddit": "python",
+    "sort": "top",
+    "time_filter": "year",
+    "posts": [
+      {
+        "id": "1abcde",
+        "title": "Structured concurrency patterns for asyncio",
+        "author": "example_user",
+        "subreddit": "python",
+        "score": 321,
+        "num_comments": 42,
+        "created_utc": 1784044800.0,
+        "url": "https://www.reddit.com/r/python/comments/1abcde/example/",
+        "permalink": "/r/python/comments/1abcde/example/",
+        "is_self": true,
+        "selftext": "A discussion of task groups and cancellation.",
+        "thumbnail": null,
+        "link_flair_text": "Discussion"
+      }
+    ],
+    "after_cursor": null,
+    "success": true
+  }
+  ```
+
 - **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `/s/` share URL, `redd.it` URL, or post ID
   - `reference` (required) — any supported Reddit post reference
   - `sort`, `limit`, and `depth` control returned comments
   - Returns `more_comment_ids` when Reddit omits parts of the comment tree
+
+  Input:
+
+  ```json
+  {
+    "reference": "https://www.reddit.com/r/python/comments/1abcde/example/",
+    "sort": "top",
+    "limit": 50,
+    "depth": 3
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "post": {
+      "title": "Structured concurrency patterns for asyncio",
+      "author": "example_user",
+      "num_comments": 42,
+      "created_utc": 1784044800.0,
+      "url": "https://www.reddit.com/r/python/comments/1abcde/example/",
+      "is_self": true,
+      "selftext": "A discussion of task groups and cancellation.",
+      "media_urls": [],
+      "comments": [
+        {
+          "id": "def456",
+          "author": "commenter",
+          "body": "This pattern also makes timeouts easier to manage.",
+          "parent_id": "t3_1abcde",
+          "created_utc": 1784048400.0,
+          "depth": 0
+        }
+      ],
+      "id": "1abcde",
+      "subreddit": "python",
+      "score": 321,
+      "permalink": "/r/python/comments/1abcde/example/",
+      "more_comment_ids": ["ghi789"]
+    },
+    "success": true
+  }
+  ```
 
 - **`fetch_more_comments`** — Expand omitted comment branches
   - `post_id` (required) — post ID with or without `t3_`
   - `comment_ids` (required) — up to 100 IDs from `more_comment_ids`
   - `sort` (optional, default: `confidence`)
 
+  Input:
+
+  ```json
+  {
+    "post_id": "1abcde",
+    "comment_ids": ["ghi789", "jkl012"],
+    "sort": "confidence"
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "post_id": "1abcde",
+    "comments": [
+      {
+        "id": "ghi789",
+        "author": "another_user",
+        "body": "Here is an expanded reply.",
+        "parent_id": "t1_def456",
+        "created_utc": 1784052000.0,
+        "depth": 1
+      }
+    ],
+    "more_comment_ids": ["mno345"],
+    "success": true
+  }
+  ```
+
 - **`fetch_subreddit_info`** — Fetch public community metadata
   - `subreddit` (required) — subreddit name without `r/`
   - Returns description, subscriber/activity counts, NSFW/quarantine flags, type, and imagery
+
+  Input:
+
+  ```json
+  {
+    "subreddit": "python"
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "display_name": "Python",
+    "title": "Python",
+    "public_description": "News about the programming language Python.",
+    "subscribers": 1496121,
+    "active_user_count": null,
+    "created_utc": 1201242956.0,
+    "over18": false,
+    "quarantined": false,
+    "subreddit_type": "public",
+    "url": "/r/Python/",
+    "icon_img": "https://styles.redditmedia.com/example-icon.png",
+    "banner_img": "https://styles.redditmedia.com/example-banner.png",
+    "success": true
+  }
+  ```
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- add JSON input and output examples for every MCP tool in the README
- present each tool as a short description followed by side-by-side collapsed Input and Output panels
- use representative values while matching the server's serialized response shapes

## Verification

- all 20 JSON snippets parse successfully
- all 10 output examples validate against their Pydantic response models
- `git diff --check` passes

## Stack

This PR intentionally targets `feat/reddit-research-tools` and builds on #15.
