### PR TITLE
Add Reddit research tools with unified post fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,65 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   </tr>
   </table>
 
+- **`search_reddit`** — Search public Reddit posts globally or within one subreddit
+
+  <table>
+  <tr>
+  <td>
+  <details>
+  <summary>Input</summary>
+
+  ```json
+  {
+    "query": "asyncio patterns",
+    "subreddit": "python",
+    "sort": "top",
+    "time_filter": "year",
+    "limit": 10,
+    "after": null
+  }
+  ```
+
+  </details>
+  </td>
+  <td>
+  <details>
+  <summary>Output</summary>
+
+  ```json
+  {
+    "query": "asyncio patterns",
+    "subreddit": "python",
+    "sort": "top",
+    "time_filter": "year",
+    "posts": [
+      {
+        "id": "1abcde",
+        "title": "Structured concurrency patterns for asyncio",
+        "author": "example_user",
+        "subreddit": "python",
+        "score": 321,
+        "num_comments": 42,
+        "created_utc": 1784044800.0,
+        "url": "https://www.reddit.com/r/python/comments/1abcde/example/",
+        "permalink": "/r/python/comments/1abcde/example/",
+        "is_self": true,
+        "selftext": "A discussion of task groups and cancellation.",
+        "thumbnail": null,
+        "link_flair_text": "Discussion"
+      }
+    ],
+    "after_cursor": null,
+    "success": true
+  }
+  ```
+
+  </details>
+
+  </td>
+  </tr>
+  </table>
+
 ### Content Fetching
 
 - **`fetch_content`** — Fetch and extract readable content from any URL
@@ -165,8 +224,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   </td>
   </tr>
   </table>
-
-### Reddit
 
 - **`fetch_subreddit`** — Browse subreddit posts
 
@@ -276,65 +333,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
       "permalink": "/r/python/comments/1abcde/example/",
       "more_comment_ids": ["ghi789", "jkl012"]
     },
-    "success": true
-  }
-  ```
-
-  </details>
-
-  </td>
-  </tr>
-  </table>
-
-- **`search_reddit`** — Search public Reddit posts globally or within one subreddit
-
-  <table>
-  <tr>
-  <td>
-  <details>
-  <summary>Input</summary>
-
-  ```json
-  {
-    "query": "asyncio patterns",
-    "subreddit": "python",
-    "sort": "top",
-    "time_filter": "year",
-    "limit": 10,
-    "after": null
-  }
-  ```
-
-  </details>
-  </td>
-  <td>
-  <details>
-  <summary>Output</summary>
-
-  ```json
-  {
-    "query": "asyncio patterns",
-    "subreddit": "python",
-    "sort": "top",
-    "time_filter": "year",
-    "posts": [
-      {
-        "id": "1abcde",
-        "title": "Structured concurrency patterns for asyncio",
-        "author": "example_user",
-        "subreddit": "python",
-        "score": 321,
-        "num_comments": 42,
-        "created_utc": 1784044800.0,
-        "url": "https://www.reddit.com/r/python/comments/1abcde/example/",
-        "permalink": "/r/python/comments/1abcde/example/",
-        "is_self": true,
-        "selftext": "A discussion of task groups and cancellation.",
-        "thumbnail": null,
-        "link_flair_text": "Discussion"
-      }
-    ],
-    "after_cursor": null,
     "success": true
   }
   ```

--- a/README.md
+++ b/README.md
@@ -282,67 +282,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   </tr>
   </table>
 
-- **`fetch_subreddit_post`** — Fetch a post with full comment tree
-
-  <table>
-  <tr>
-  <td>
-  <details>
-  <summary>Input</summary>
-
-  ```json
-  {
-    "subreddit": "python",
-    "post_id": "1abcde",
-    "sort": "confidence",
-    "limit": 100,
-    "depth": 5
-  }
-  ```
-
-  </details>
-  </td>
-  <td>
-  <details>
-  <summary>Output</summary>
-
-  ```json
-  {
-    "post": {
-      "title": "What are your favorite asyncio patterns?",
-      "author": "example_user",
-      "num_comments": 48,
-      "created_utc": 1784044800.0,
-      "url": "https://www.reddit.com/r/python/comments/1abcde/example/",
-      "is_self": true,
-      "selftext": "Share the patterns that have worked well for you.",
-      "media_urls": [],
-      "comments": [
-        {
-          "id": "def456",
-          "author": "commenter",
-          "body": "Task groups make cancellation much easier to reason about.",
-          "parent_id": "t3_1abcde",
-          "created_utc": 1784048400.0,
-          "depth": 0
-        }
-      ],
-      "id": "1abcde",
-      "subreddit": "python",
-      "score": 215,
-      "permalink": "/r/python/comments/1abcde/example/",
-      "more_comment_ids": ["ghi789", "jkl012"]
-    },
-    "success": true
-  }
-  ```
-
-  </details>
-
-  </td>
-  </tr>
-  </table>
-
 - **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `/s/` share URL, `redd.it` URL, or post ID
 
   <table>
@@ -594,7 +533,7 @@ docker compose --profile vpn up -d
 
 When using the VPN profile:
 - **SearxNG** shares Gluetun's network stack — all search engine queries route through the VPN
-- **Fetcher tools** (fetch_content, fetch_youtube_content, fetch_subreddit, fetch_subreddit_post) use the HTTP proxy at `PROXY_URL`
+- **Fetcher tools** (fetch_content, fetch_youtube_content, fetch_subreddit, fetch_reddit_post) use the HTTP proxy at `PROXY_URL`
 - Without VPN (`docker compose up -d`), everything connects directly
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 ### Search
 
 - **`search`** — Web search via SearxNG
-  - `query` (required) — search terms
-  - `max_results` (optional, default: 10, max: 25)
-  - `categories` (optional) — comma-separated: `general`, `news`, `science`, `it`, `music`
-  - `time_range` (optional) — `day`, `month`, or `year`
-  - `language` (optional) — ISO language code (e.g., `en`, `de`, `fr`)
-  - Returns: title, url, content snippet, score
 
   Input:
 
@@ -44,9 +38,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`search_videos`** — YouTube video search
-  - `query` (required) — video search terms
-  - `max_results` (optional, default: 10, max: 20)
-  - Returns: url, title, author, content summary, length
 
   Input:
 
@@ -74,10 +65,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 ### Content Fetching
 
 - **`fetch_content`** — Fetch and extract readable content from any URL
-  - `url` (required) — URL to fetch
-  - `offset` (optional, default: 0) — pagination offset
-  - Automatic fallback chain: static fetch → JS rendering (if empty) → Jina Reader (if still empty/error)
-  - Content is returned in 30K character chunks. Use `next_offset` from the response to paginate.
 
   Input:
 
@@ -103,9 +90,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`fetch_youtube_content`** — Download and transcribe YouTube video audio
-  - `video_id` (required) — video ID or full URL (e.g. `dQw4w9WgXcQ` or `https://www.youtube.com/watch?v=dQw4w9WgXcQ`)
-  - Returns: video_id, transcript, transcript_length
-  - Requires: STT endpoint (see [Configuration](#configuration))
 
   Input:
 
@@ -129,12 +113,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 ### Reddit
 
 - **`fetch_subreddit`** — Browse subreddit posts
-  - `subreddit` (required) — subreddit name without `r/` prefix
-  - `sort` (optional, default: `hot`) — hot, new, top, rising, controversial
-  - `time_filter` (optional) — hour, day, week, month, year, all (for top/controversial)
-  - `limit` (optional, default: 25, max: 100)
-  - `after` (optional) — pagination cursor from previous response
-  - Returns: post summaries with title, author, score, comment count, url
 
   Input:
 
@@ -178,12 +156,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`fetch_subreddit_post`** — Fetch a post with full comment tree
-  - `subreddit` (required) — subreddit name without `r/` prefix
-  - `post_id` (required) — post ID without `t3_` prefix
-  - `sort` (optional, default: `confidence`) — confidence, top, new, controversial, old, qa
-  - `limit` (optional, default: 100, max: 500) — max comments
-  - `depth` (optional) — max reply nesting depth
-  - Returns: post detail with selftext, media URLs, flattened comments, and IDs for omitted comments
 
   Input:
 
@@ -231,10 +203,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`search_reddit`** — Search public Reddit posts globally or within one subreddit
-  - `query` (required) — search terms
-  - `subreddit` (optional) — restrict results to one subreddit
-  - `sort` (optional, default: `relevance`) — relevance, hot, top, new, comments
-  - `time_filter`, `limit`, and `after` support time filtering and pagination
 
   Input:
 
@@ -280,9 +248,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `/s/` share URL, `redd.it` URL, or post ID
-  - `reference` (required) — any supported Reddit post reference
-  - `sort`, `limit`, and `depth` control returned comments
-  - Returns `more_comment_ids` when Reddit omits parts of the comment tree
 
   Input:
 
@@ -329,9 +294,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`fetch_more_comments`** — Expand omitted comment branches
-  - `post_id` (required) — post ID with or without `t3_`
-  - `comment_ids` (required) — up to 100 IDs from `more_comment_ids`
-  - `sort` (optional, default: `confidence`)
 
   Input:
 
@@ -364,8 +326,6 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
 - **`fetch_subreddit_info`** — Fetch public community metadata
-  - `subreddit` (required) — subreddit name without `r/`
-  - Returns description, subscriber/activity counts, NSFW/quarantine flags, type, and imagery
 
   Input:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
 - **`search`** — Web search via SearxNG
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -24,7 +25,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   [
@@ -37,9 +41,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ]
   ```
 
+  </details>
+
 - **`search_videos`** — YouTube video search
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -48,7 +55,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   [
@@ -62,11 +72,14 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ]
   ```
 
+  </details>
+
 ### Content Fetching
 
 - **`fetch_content`** — Fetch and extract readable content from any URL
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -75,7 +88,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -89,9 +105,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 - **`fetch_youtube_content`** — Download and transcribe YouTube video audio
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -99,7 +118,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -110,11 +132,14 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 ### Reddit
 
 - **`fetch_subreddit`** — Browse subreddit posts
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -126,7 +151,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -155,9 +183,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 - **`fetch_subreddit_post`** — Fetch a post with full comment tree
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -169,7 +200,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -202,9 +236,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 - **`search_reddit`** — Search public Reddit posts globally or within one subreddit
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -217,7 +254,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -247,9 +287,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 - **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `/s/` share URL, `redd.it` URL, or post ID
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -260,7 +303,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -293,9 +339,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 - **`fetch_more_comments`** — Expand omitted comment branches
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -305,7 +354,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -325,9 +377,12 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
+  </details>
+
 - **`fetch_subreddit_info`** — Fetch public community metadata
 
-  Input:
+  <details>
+  <summary>Input</summary>
 
   ```json
   {
@@ -335,7 +390,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   }
   ```
 
-  Output:
+  </details>
+
+  <details>
+  <summary>Output</summary>
 
   ```json
   {
@@ -354,6 +412,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
     "success": true
   }
   ```
+
+  </details>
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,27 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   - `sort` (optional, default: `confidence`) — confidence, top, new, controversial, old, qa
   - `limit` (optional, default: 100, max: 500) — max comments
   - `depth` (optional) — max reply nesting depth
-  - Returns: post detail with selftext, media URLs, and nested comments
+  - Returns: post detail with selftext, media URLs, flattened comments, and IDs for omitted comments
+
+- **`search_reddit`** — Search public Reddit posts globally or within one subreddit
+  - `query` (required) — search terms
+  - `subreddit` (optional) — restrict results to one subreddit
+  - `sort` (optional, default: `relevance`) — relevance, hot, top, new, comments
+  - `time_filter`, `limit`, and `after` support time filtering and pagination
+
+- **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `redd.it` URL, or post ID
+  - `reference` (required) — any supported Reddit post reference
+  - `sort`, `limit`, and `depth` control returned comments
+  - Returns `more_comment_ids` when Reddit omits parts of the comment tree
+
+- **`fetch_more_comments`** — Expand omitted comment branches
+  - `post_id` (required) — post ID with or without `t3_`
+  - `comment_ids` (required) — up to 100 IDs from `more_comment_ids`
+  - `sort` (optional, default: `confidence`)
+
+- **`fetch_subreddit_info`** — Fetch public community metadata
+  - `subreddit` (required) — subreddit name without `r/`
+  - Returns description, subscriber/activity counts, NSFW/quarantine flags, type, and imagery
 
 ## Quick Start
 
@@ -108,6 +128,9 @@ mcporter call webintel-mcp.search query="AI breakthroughs" categories="science" 
 mcporter call webintel-mcp.search query="open source LLM" categories="news" time_range="day" language="en"
 mcporter call webintel-mcp.fetch_content url="https://example.com"
 mcporter call webintel-mcp.fetch_subreddit subreddit="python" sort="top" time_filter="week"
+mcporter call webintel-mcp.search_reddit query="asyncio patterns" subreddit="python" sort="top" time_filter="year"
+mcporter call webintel-mcp.fetch_reddit_post reference="https://www.reddit.com/r/python/comments/POST_ID/title/"
+mcporter call webintel-mcp.fetch_subreddit_info subreddit="python"
 ```
 
 ## Docker Options

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
 - **`search`** — Web search via SearxNG
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -26,7 +29,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -43,8 +47,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`search_videos`** — YouTube video search
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -56,7 +67,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -74,10 +86,17 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 ### Content Fetching
 
 - **`fetch_content`** — Fetch and extract readable content from any URL
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -89,7 +108,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -107,8 +127,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`fetch_youtube_content`** — Download and transcribe YouTube video audio
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -119,7 +146,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -134,10 +162,17 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 ### Reddit
 
 - **`fetch_subreddit`** — Browse subreddit posts
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -152,7 +187,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -185,8 +221,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`fetch_subreddit_post`** — Fetch a post with full comment tree
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -201,7 +244,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -238,8 +282,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`search_reddit`** — Search public Reddit posts globally or within one subreddit
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -255,7 +306,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -289,8 +341,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `/s/` share URL, `redd.it` URL, or post ID
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -304,7 +363,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -341,8 +401,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`fetch_more_comments`** — Expand omitted comment branches
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -355,7 +422,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -379,8 +447,15 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
 
   </details>
 
+  </td>
+  </tr>
+  </table>
+
 - **`fetch_subreddit_info`** — Fetch public community metadata
 
+  <table>
+  <tr>
+  <td>
   <details>
   <summary>Input</summary>
 
@@ -391,7 +466,8 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
-
+  </td>
+  <td>
   <details>
   <summary>Output</summary>
 
@@ -414,6 +490,10 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   ```
 
   </details>
+
+  </td>
+  </tr>
+  </table>
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,58 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   - `language` (optional) — ISO language code (e.g., `en`, `de`, `fr`)
   - Returns: title, url, content snippet, score
 
+  Input:
+
+  ```json
+  {
+    "query": "Python 3.14 release highlights",
+    "max_results": 2,
+    "categories": "it,news",
+    "time_range": "month",
+    "language": "en"
+  }
+  ```
+
+  Output:
+
+  ```json
+  [
+    {
+      "title": "What's New In Python 3.14",
+      "url": "https://docs.python.org/3.14/whatsnew/3.14.html",
+      "content": "Python 3.14 adds new syntax, runtime improvements, and tooling updates.",
+      "score": 1.0
+    }
+  ]
+  ```
+
 - **`search_videos`** — YouTube video search
   - `query` (required) — video search terms
   - `max_results` (optional, default: 10, max: 20)
   - Returns: url, title, author, content summary, length
+
+  Input:
+
+  ```json
+  {
+    "query": "asyncio tutorial",
+    "max_results": 2
+  }
+  ```
+
+  Output:
+
+  ```json
+  [
+    {
+      "url": "https://www.youtube.com/watch?v=example123",
+      "title": "Python Asyncio Explained",
+      "author": "Example Developer",
+      "content": "A practical introduction to async and await in Python.",
+      "length": "12:34"
+    }
+  ]
+  ```
 
 ### Content Fetching
 
@@ -31,10 +79,52 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   - Automatic fallback chain: static fetch → JS rendering (if empty) → Jina Reader (if still empty/error)
   - Content is returned in 30K character chunks. Use `next_offset` from the response to paginate.
 
+  Input:
+
+  ```json
+  {
+    "url": "https://example.com/long-article",
+    "offset": 0
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "content": "Example Domain\n\nThis domain is for use in illustrative examples...",
+    "content_length": 66,
+    "is_truncated": false,
+    "offset": 0,
+    "next_offset": null,
+    "total_length": 66,
+    "success": true
+  }
+  ```
+
 - **`fetch_youtube_content`** — Download and transcribe YouTube video audio
   - `video_id` (required) — video ID or full URL (e.g. `dQw4w9WgXcQ` or `https://www.youtube.com/watch?v=dQw4w9WgXcQ`)
   - Returns: video_id, transcript, transcript_length
   - Requires: STT endpoint (see [Configuration](#configuration))
+
+  Input:
+
+  ```json
+  {
+    "video_id": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "video_id": "dQw4w9WgXcQ",
+    "transcript": "We're no strangers to love...",
+    "transcript_length": 33,
+    "success": true
+  }
+  ```
 
 ### Reddit
 
@@ -46,6 +136,47 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   - `after` (optional) — pagination cursor from previous response
   - Returns: post summaries with title, author, score, comment count, url
 
+  Input:
+
+  ```json
+  {
+    "subreddit": "python",
+    "sort": "top",
+    "time_filter": "week",
+    "limit": 2,
+    "after": null
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "subreddit": "python",
+    "sort": "top",
+    "time_filter": "week",
+    "posts": [
+      {
+        "id": "1abcde",
+        "title": "A useful Python project",
+        "author": "example_user",
+        "subreddit": "python",
+        "score": 142,
+        "num_comments": 27,
+        "created_utc": 1784044800.0,
+        "url": "https://example.com/python-project",
+        "permalink": "/r/python/comments/1abcde/a_useful_python_project/",
+        "is_self": false,
+        "selftext": null,
+        "thumbnail": "https://example.com/thumbnail.jpg",
+        "link_flair_text": "Resource"
+      }
+    ],
+    "after_cursor": "t3_1abcde",
+    "success": true
+  }
+  ```
+
 - **`fetch_subreddit_post`** — Fetch a post with full comment tree
   - `subreddit` (required) — subreddit name without `r/` prefix
   - `post_id` (required) — post ID without `t3_` prefix
@@ -54,25 +185,215 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   - `depth` (optional) — max reply nesting depth
   - Returns: post detail with selftext, media URLs, flattened comments, and IDs for omitted comments
 
+  Input:
+
+  ```json
+  {
+    "subreddit": "python",
+    "post_id": "1abcde",
+    "sort": "confidence",
+    "limit": 100,
+    "depth": 5
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "post": {
+      "title": "What are your favorite asyncio patterns?",
+      "author": "example_user",
+      "num_comments": 48,
+      "created_utc": 1784044800.0,
+      "url": "https://www.reddit.com/r/python/comments/1abcde/example/",
+      "is_self": true,
+      "selftext": "Share the patterns that have worked well for you.",
+      "media_urls": [],
+      "comments": [
+        {
+          "id": "def456",
+          "author": "commenter",
+          "body": "Task groups make cancellation much easier to reason about.",
+          "parent_id": "t3_1abcde",
+          "created_utc": 1784048400.0,
+          "depth": 0
+        }
+      ],
+      "id": "1abcde",
+      "subreddit": "python",
+      "score": 215,
+      "permalink": "/r/python/comments/1abcde/example/",
+      "more_comment_ids": ["ghi789", "jkl012"]
+    },
+    "success": true
+  }
+  ```
+
 - **`search_reddit`** — Search public Reddit posts globally or within one subreddit
   - `query` (required) — search terms
   - `subreddit` (optional) — restrict results to one subreddit
   - `sort` (optional, default: `relevance`) — relevance, hot, top, new, comments
   - `time_filter`, `limit`, and `after` support time filtering and pagination
 
+  Input:
+
+  ```json
+  {
+    "query": "asyncio patterns",
+    "subreddit": "python",
+    "sort": "top",
+    "time_filter": "year",
+    "limit": 10,
+    "after": null
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "query": "asyncio patterns",
+    "subreddit": "python",
+    "sort": "top",
+    "time_filter": "year",
+    "posts": [
+      {
+        "id": "1abcde",
+        "title": "Structured concurrency patterns for asyncio",
+        "author": "example_user",
+        "subreddit": "python",
+        "score": 321,
+        "num_comments": 42,
+        "created_utc": 1784044800.0,
+        "url": "https://www.reddit.com/r/python/comments/1abcde/example/",
+        "permalink": "/r/python/comments/1abcde/example/",
+        "is_self": true,
+        "selftext": "A discussion of task groups and cancellation.",
+        "thumbnail": null,
+        "link_flair_text": "Discussion"
+      }
+    ],
+    "after_cursor": null,
+    "success": true
+  }
+  ```
+
 - **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `/s/` share URL, `redd.it` URL, or post ID
   - `reference` (required) — any supported Reddit post reference
   - `sort`, `limit`, and `depth` control returned comments
   - Returns `more_comment_ids` when Reddit omits parts of the comment tree
+
+  Input:
+
+  ```json
+  {
+    "reference": "https://www.reddit.com/r/python/comments/1abcde/example/",
+    "sort": "top",
+    "limit": 50,
+    "depth": 3
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "post": {
+      "title": "Structured concurrency patterns for asyncio",
+      "author": "example_user",
+      "num_comments": 42,
+      "created_utc": 1784044800.0,
+      "url": "https://www.reddit.com/r/python/comments/1abcde/example/",
+      "is_self": true,
+      "selftext": "A discussion of task groups and cancellation.",
+      "media_urls": [],
+      "comments": [
+        {
+          "id": "def456",
+          "author": "commenter",
+          "body": "This pattern also makes timeouts easier to manage.",
+          "parent_id": "t3_1abcde",
+          "created_utc": 1784048400.0,
+          "depth": 0
+        }
+      ],
+      "id": "1abcde",
+      "subreddit": "python",
+      "score": 321,
+      "permalink": "/r/python/comments/1abcde/example/",
+      "more_comment_ids": ["ghi789"]
+    },
+    "success": true
+  }
+  ```
 
 - **`fetch_more_comments`** — Expand omitted comment branches
   - `post_id` (required) — post ID with or without `t3_`
   - `comment_ids` (required) — up to 100 IDs from `more_comment_ids`
   - `sort` (optional, default: `confidence`)
 
+  Input:
+
+  ```json
+  {
+    "post_id": "1abcde",
+    "comment_ids": ["ghi789", "jkl012"],
+    "sort": "confidence"
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "post_id": "1abcde",
+    "comments": [
+      {
+        "id": "ghi789",
+        "author": "another_user",
+        "body": "Here is an expanded reply.",
+        "parent_id": "t1_def456",
+        "created_utc": 1784052000.0,
+        "depth": 1
+      }
+    ],
+    "more_comment_ids": ["mno345"],
+    "success": true
+  }
+  ```
+
 - **`fetch_subreddit_info`** — Fetch public community metadata
   - `subreddit` (required) — subreddit name without `r/`
   - Returns description, subscriber/activity counts, NSFW/quarantine flags, type, and imagery
+
+  Input:
+
+  ```json
+  {
+    "subreddit": "python"
+  }
+  ```
+
+  Output:
+
+  ```json
+  {
+    "display_name": "Python",
+    "title": "Python",
+    "public_description": "News about the programming language Python.",
+    "subscribers": 1496121,
+    "active_user_count": null,
+    "created_utc": 1201242956.0,
+    "over18": false,
+    "quarantined": false,
+    "subreddit_type": "public",
+    "url": "/r/Python/",
+    "icon_img": "https://styles.redditmedia.com/example-icon.png",
+    "banner_img": "https://styles.redditmedia.com/example-banner.png",
+    "success": true
+  }
+  ```
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A FastMCP server providing web search, content fetching, YouTube transcription, 
   - `sort` (optional, default: `relevance`) — relevance, hot, top, new, comments
   - `time_filter`, `limit`, and `after` support time filtering and pagination
 
-- **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `redd.it` URL, or post ID
+- **`fetch_reddit_post`** — Fetch a post using a URL, permalink, `/s/` share URL, `redd.it` URL, or post ID
   - `reference` (required) — any supported Reddit post reference
   - `sort`, `limit`, and `depth` control returned comments
   - Returns `more_comment_ids` when Reddit omits parts of the comment tree

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -3,7 +3,7 @@ Pydantic models for search results and API responses
 """
 
 from typing import List, Optional, Union
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 # Specific data models for different search types
@@ -140,6 +140,11 @@ class RedditPostDetail(BaseModel):
     selftext: Optional[str] = None
     media_urls: List[str] = []  # Extracted media/image URLs
     comments: List[RedditComment] = []
+    id: Optional[str] = None
+    subreddit: Optional[str] = None
+    score: Optional[int] = None
+    permalink: Optional[str] = None
+    more_comment_ids: List[str] = Field(default_factory=list)
 
 
 class SubredditPostsOutput(BaseModel):
@@ -155,4 +160,40 @@ class SubredditPostsOutput(BaseModel):
 class RedditPostOutput(BaseModel):
     """Output model for single Reddit post with comments."""
     post: RedditPostDetail
+    success: bool
+
+
+class RedditSearchOutput(BaseModel):
+    """Output model for Reddit post search."""
+    query: str
+    subreddit: Optional[str] = None
+    sort: str
+    time_filter: Optional[str] = None
+    posts: List[RedditPostSummary]
+    after_cursor: Optional[str] = None
+    success: bool
+
+
+class RedditCommentsOutput(BaseModel):
+    """Output model for an expanded set of Reddit comments."""
+    post_id: str
+    comments: List[RedditComment]
+    more_comment_ids: List[str] = Field(default_factory=list)
+    success: bool
+
+
+class SubredditInfoOutput(BaseModel):
+    """Public metadata describing a subreddit."""
+    display_name: str
+    title: str
+    public_description: str
+    subscribers: Optional[int] = None
+    active_user_count: Optional[int] = None
+    created_utc: Optional[float] = None
+    over18: bool = False
+    quarantined: bool = False
+    subreddit_type: Optional[str] = None
+    url: str
+    icon_img: Optional[str] = None
+    banner_img: Optional[str] = None
     success: bool

--- a/src/core/reddit_fetcher.py
+++ b/src/core/reddit_fetcher.py
@@ -4,7 +4,7 @@ import asyncio
 import re
 import time
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
@@ -76,6 +76,71 @@ class RedditFetcher:
         if not post_id or not cls.POST_ID_PATTERN.fullmatch(post_id):
             raise SearchException("Could not find a valid post ID in the Reddit URL")
         return post_id.lower(), subreddit
+
+    async def resolve_post_reference(self, reference: str) -> tuple[str, Optional[str]]:
+        """Resolve canonical references directly and Reddit share URLs via redirects."""
+        try:
+            return self.parse_post_reference(reference)
+        except SearchException as e:
+            parse_error = e
+
+        share_url = reference.strip()
+        if share_url.startswith("/"):
+            share_url = f"https://www.reddit.com{share_url}"
+        parsed = urlparse(share_url)
+        host = (parsed.hostname or "").lower()
+        parts = [part for part in parsed.path.split("/") if part]
+        is_reddit_host = host == "reddit.com" or host.endswith(".reddit.com")
+        is_share_url = (
+            parsed.scheme in {"http", "https"}
+            and is_reddit_host
+            and len(parts) >= 4
+            and parts[0].lower() == "r"
+            and parts[2].lower() == "s"
+        )
+        if not is_share_url:
+            raise parse_error
+
+        try:
+            async with httpx.AsyncClient(proxy=SearchConfig.REDDIT_PROXY_URL) as client:
+                for _ in range(5):
+                    response = await client.get(
+                        share_url,
+                        headers=self.headers,
+                        follow_redirects=False,
+                        timeout=SearchConfig.FETCH_TIMEOUT,
+                    )
+                    location = response.headers.get("location")
+                    if not response.is_redirect or not location:
+                        response.raise_for_status()
+                        break
+
+                    share_url = urljoin(str(response.url), location)
+                    try:
+                        return self.parse_post_reference(share_url)
+                    except SearchException:
+                        redirect = urlparse(share_url)
+                        redirect_host = (redirect.hostname or "").lower()
+                        if not (
+                            redirect.scheme in {"http", "https"}
+                            and (
+                                redirect_host == "reddit.com"
+                                or redirect_host.endswith(".reddit.com")
+                            )
+                        ):
+                            raise SearchException(
+                                "Reddit share URL redirected outside Reddit"
+                            )
+        except httpx.TimeoutException:
+            raise SearchException("Reddit share URL resolution timed out")
+        except httpx.HTTPStatusError as e:
+            raise SearchException(
+                f"Reddit share URL resolution failed with HTTP {e.response.status_code}"
+            )
+        except httpx.HTTPError as e:
+            raise SearchException(f"Reddit share URL resolution failed: {e}")
+
+        raise SearchException("Reddit share URL did not resolve to a post")
 
     async def _get_access_token(self, force_refresh: bool = False) -> str:
         """Return a cached application-only OAuth token."""

--- a/src/core/reddit_fetcher.py
+++ b/src/core/reddit_fetcher.py
@@ -1,8 +1,10 @@
 """Reddit content fetching using Reddit's OAuth Data API."""
 
 import asyncio
+import re
 import time
 from typing import Optional
+from urllib.parse import urlparse
 
 import httpx
 
@@ -15,6 +17,8 @@ class RedditFetcher:
     BASE_URL = "https://oauth.reddit.com"
     TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
     TOKEN_EXPIRY_MARGIN = 60
+    SUBREDDIT_PATTERN = re.compile(r"^[A-Za-z0-9_]{1,100}$")
+    POST_ID_PATTERN = re.compile(r"^[a-z0-9]{1,12}$", re.IGNORECASE)
     
     def __init__(self):
         self.headers = {
@@ -30,6 +34,48 @@ class RedditFetcher:
                 "Reddit OAuth is not configured. Set REDDIT_CLIENT_ID and "
                 "REDDIT_CLIENT_SECRET."
             )
+
+    @classmethod
+    def _validate_subreddit(cls, subreddit: str) -> str:
+        subreddit = subreddit.removeprefix("r/").strip()
+        if not cls.SUBREDDIT_PATTERN.fullmatch(subreddit):
+            raise SearchException("Invalid subreddit name")
+        return subreddit
+
+    @classmethod
+    def parse_post_reference(cls, reference: str) -> tuple[str, Optional[str]]:
+        """Extract a post ID and optional subreddit from a Reddit URL or ID."""
+        reference = reference.strip()
+        plain_id = reference.removeprefix("t3_")
+        if cls.POST_ID_PATTERN.fullmatch(plain_id):
+            return plain_id.lower(), None
+
+        if reference.startswith("/"):
+            reference = f"https://www.reddit.com{reference}"
+        parsed = urlparse(reference)
+        host = (parsed.hostname or "").lower()
+        is_reddit_host = host == "reddit.com" or host.endswith(".reddit.com")
+        if (
+            parsed.scheme not in {"http", "https"}
+            or (not is_reddit_host and host != "redd.it")
+        ):
+            raise SearchException("Expected a Reddit post URL, redd.it URL, or post ID")
+
+        parts = [part for part in parsed.path.split("/") if part]
+        subreddit = None
+        post_id = None
+        if host == "redd.it" and parts:
+            post_id = parts[0]
+        elif "comments" in parts:
+            comments_index = parts.index("comments")
+            if comments_index + 1 < len(parts):
+                post_id = parts[comments_index + 1]
+            if comments_index >= 2 and parts[comments_index - 2].lower() == "r":
+                subreddit = cls._validate_subreddit(parts[comments_index - 1])
+
+        if not post_id or not cls.POST_ID_PATTERN.fullmatch(post_id):
+            raise SearchException("Could not find a valid post ID in the Reddit URL")
+        return post_id.lower(), subreddit
 
     async def _get_access_token(self, force_refresh: bool = False) -> str:
         """Return a cached application-only OAuth token."""
@@ -137,6 +183,7 @@ class RedditFetcher:
             SearchException: If fetching fails
         """
         # Validate inputs
+        subreddit = self._validate_subreddit(subreddit)
         valid_sorts = ["hot", "new", "top", "rising", "controversial"]
         if sort not in valid_sorts:
             raise SearchException(f"Invalid sort: {sort}. Must be one of {valid_sorts}")
@@ -183,7 +230,7 @@ class RedditFetcher:
     
     async def fetch_post_with_comments(
         self,
-        subreddit: str,
+        subreddit: Optional[str],
         post_id: str,
         sort: str = "confidence",
         limit: int = 100,
@@ -195,7 +242,7 @@ class RedditFetcher:
         Fetch a single post with comments.
         
         Args:
-            subreddit: Subreddit name (without r/ prefix)
+            subreddit: Optional subreddit name (without r/ prefix)
             post_id: Post ID (without t3_ prefix)
             sort: Comment sort (confidence, top, new, controversial, old, qa)
             limit: Max comments to fetch (1-500, default 100)
@@ -210,6 +257,11 @@ class RedditFetcher:
             SearchException: If fetching fails
         """
         # Validate inputs
+        if subreddit:
+            subreddit = self._validate_subreddit(subreddit)
+        post_id = post_id.removeprefix("t3_").lower()
+        if not self.POST_ID_PATTERN.fullmatch(post_id):
+            raise SearchException("Invalid Reddit post ID")
         valid_sorts = ["confidence", "top", "new", "controversial", "old", "qa"]
         if sort not in valid_sorts:
             raise SearchException(f"Invalid sort: {sort}. Must be one of {valid_sorts}")
@@ -223,9 +275,8 @@ class RedditFetcher:
         if context is not None and (context < 0 or context > 8):
             raise SearchException("Context must be between 0 and 8")
         
-        # Build URL - need to get the slug from the post first or use a generic path
-        # Reddit is flexible with the slug, so we can use a placeholder
-        url = f"{self.BASE_URL}/r/{subreddit}/comments/{post_id}.json"
+        path = f"/r/{subreddit}/comments/{post_id}.json" if subreddit else f"/comments/{post_id}.json"
+        url = f"{self.BASE_URL}{path}"
         
         # Build query params
         params = {
@@ -261,3 +312,117 @@ class RedditFetcher:
             raise
         except Exception as e:
             raise SearchException(f"Failed to fetch post: {str(e)}")
+
+    async def search_posts(
+        self,
+        query: str,
+        subreddit: Optional[str] = None,
+        sort: str = "relevance",
+        time_filter: Optional[str] = None,
+        limit: int = 25,
+        after: Optional[str] = None,
+    ) -> dict:
+        """Search public Reddit posts globally or within one subreddit."""
+        query = query.strip()
+        if not query:
+            raise SearchException("Reddit search query cannot be empty")
+        if len(query) > 500:
+            raise SearchException("Reddit search query cannot exceed 500 characters")
+        valid_sorts = ["relevance", "hot", "top", "new", "comments"]
+        if sort not in valid_sorts:
+            raise SearchException(f"Invalid search sort: {sort}. Must be one of {valid_sorts}")
+        valid_time_filters = ["hour", "day", "week", "month", "year", "all"]
+        if time_filter and time_filter not in valid_time_filters:
+            raise SearchException(
+                f"Invalid time filter: {time_filter}. Must be one of {valid_time_filters}"
+            )
+        if limit < 1 or limit > 100:
+            raise SearchException("Limit must be between 1 and 100")
+
+        if subreddit:
+            subreddit = self._validate_subreddit(subreddit)
+            url = f"{self.BASE_URL}/r/{subreddit}/search.json"
+        else:
+            url = f"{self.BASE_URL}/search.json"
+        params = {"q": query, "sort": sort, "limit": limit, "raw_json": 1}
+        if subreddit:
+            params["restrict_sr"] = "on"
+        if time_filter:
+            params["t"] = time_filter
+        if after:
+            params["after"] = after
+
+        try:
+            response = await self._get(url, params)
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 429:
+                raise SearchException(self._rate_limit_message(e.response))
+            raise SearchException(f"Reddit search failed with HTTP {e.response.status_code}")
+        except httpx.TimeoutException:
+            raise SearchException("Reddit search request timed out")
+
+    async def fetch_more_comments(
+        self,
+        post_id: str,
+        comment_ids: list[str],
+        sort: str = "confidence",
+    ) -> dict:
+        """Expand comment IDs returned in a thread's `more` placeholders."""
+        post_id = post_id.removeprefix("t3_").lower()
+        if not self.POST_ID_PATTERN.fullmatch(post_id):
+            raise SearchException("Invalid Reddit post ID")
+        if not comment_ids or len(comment_ids) > 100:
+            raise SearchException("comment_ids must contain between 1 and 100 IDs")
+        clean_ids = []
+        for comment_id in comment_ids:
+            clean_id = comment_id.removeprefix("t1_").lower()
+            if not self.POST_ID_PATTERN.fullmatch(clean_id):
+                raise SearchException(f"Invalid Reddit comment ID: {comment_id}")
+            if clean_id not in clean_ids:
+                clean_ids.append(clean_id)
+        valid_sorts = ["confidence", "top", "new", "controversial", "old", "qa"]
+        if sort not in valid_sorts:
+            raise SearchException(f"Invalid comment sort: {sort}. Must be one of {valid_sorts}")
+
+        params = {
+            "api_type": "json",
+            "link_id": f"t3_{post_id}",
+            "children": ",".join(clean_ids),
+            "sort": sort,
+            "limit_children": "false",
+            "raw_json": 1,
+        }
+        try:
+            response = await self._get(f"{self.BASE_URL}/api/morechildren", params)
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 429:
+                raise SearchException(self._rate_limit_message(e.response))
+            raise SearchException(
+                f"Reddit comment expansion failed with HTTP {e.response.status_code}"
+            )
+        except httpx.TimeoutException:
+            raise SearchException("Reddit comment expansion timed out")
+
+    async def fetch_subreddit_info(self, subreddit: str) -> dict:
+        """Fetch public metadata for a subreddit."""
+        subreddit = self._validate_subreddit(subreddit)
+        try:
+            response = await self._get(
+                f"{self.BASE_URL}/r/{subreddit}/about.json",
+                {"raw_json": 1},
+            )
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise SearchException(f"Subreddit not found: r/{subreddit}")
+            if e.response.status_code == 403:
+                raise SearchException(f"Reddit denied access to r/{subreddit}")
+            if e.response.status_code == 429:
+                raise SearchException(self._rate_limit_message(e.response))
+            raise SearchException(
+                f"Subreddit metadata request failed with HTTP {e.response.status_code}"
+            )
+        except httpx.TimeoutException:
+            raise SearchException("Subreddit metadata request timed out")

--- a/src/server/handlers.py
+++ b/src/server/handlers.py
@@ -18,7 +18,10 @@ from ..core.models import (
     RedditComment,
     RedditPostDetail,
     SubredditPostsOutput,
-    RedditPostOutput
+    RedditPostOutput,
+    RedditSearchOutput,
+    RedditCommentsOutput,
+    SubredditInfoOutput,
 )
 
 
@@ -257,6 +260,23 @@ class SearchHandlers:
                 comments.extend(replies)
         
         return comments
+
+    def _collect_more_comment_ids(self, children: List[Dict]) -> List[str]:
+        """Collect expandable comment IDs from nested Reddit `more` objects."""
+        comment_ids = []
+        for child in children:
+            if child.get("kind") == "more":
+                for comment_id in child.get("data", {}).get("children", []):
+                    if comment_id and comment_id not in comment_ids:
+                        comment_ids.append(comment_id)
+                continue
+            replies = child.get("data", {}).get("replies")
+            if isinstance(replies, dict):
+                nested = replies.get("data", {}).get("children", [])
+                for comment_id in self._collect_more_comment_ids(nested):
+                    if comment_id not in comment_ids:
+                        comment_ids.append(comment_id)
+        return comment_ids
     
     def _extract_media_urls(self, post_data: Dict[str, Any]) -> List[str]:
         """Extract media URLs from Reddit post data."""
@@ -396,7 +416,12 @@ class SearchHandlers:
                 is_self=post_data.get("is_self", False),
                 selftext=post_data.get("selftext") if post_data.get("selftext") else None,
                 media_urls=media_urls,
-                comments=comments
+                comments=comments,
+                id=post_data.get("id"),
+                subreddit=post_data.get("subreddit"),
+                score=post_data.get("score", 0),
+                permalink=post_data.get("permalink"),
+                more_comment_ids=self._collect_more_comment_ids(comments_listing),
             )
             
             return RedditPostOutput(
@@ -405,5 +430,114 @@ class SearchHandlers:
             )
         except SearchException as e:
             raise ToolError(f"Failed to fetch Reddit post: {str(e)}")
+        except Exception as e:
+            raise ToolError(f"Unexpected error: {str(e)}")
+
+    async def search_reddit(
+        self,
+        query: str,
+        subreddit: str = None,
+        sort: str = "relevance",
+        time_filter: str = None,
+        limit: int = 25,
+        after: str = None,
+    ) -> RedditSearchOutput:
+        """Search Reddit posts globally or within a subreddit."""
+        try:
+            response = await self.reddit_fetcher.search_posts(
+                query=query,
+                subreddit=subreddit,
+                sort=sort,
+                time_filter=time_filter,
+                limit=limit,
+                after=after,
+            )
+            data = response.get("data", {})
+            posts = [
+                self._parse_reddit_post_summary(child.get("data", {}))
+                for child in data.get("children", [])
+                if child.get("kind") == "t3"
+            ]
+            return RedditSearchOutput(
+                query=query,
+                subreddit=subreddit,
+                sort=sort,
+                time_filter=time_filter,
+                posts=posts,
+                after_cursor=data.get("after"),
+                success=True,
+            )
+        except SearchException as e:
+            raise ToolError(f"Failed to search Reddit: {str(e)}")
+        except Exception as e:
+            raise ToolError(f"Unexpected error: {str(e)}")
+
+    async def fetch_reddit_post(
+        self,
+        reference: str,
+        sort: str = "confidence",
+        limit: int = 100,
+        depth: int = None,
+    ) -> RedditPostOutput:
+        """Fetch a post from its URL, permalink, redd.it URL, or post ID."""
+        try:
+            post_id, subreddit = self.reddit_fetcher.parse_post_reference(reference)
+        except SearchException as e:
+            raise ToolError(f"Invalid Reddit post reference: {str(e)}")
+        return await self.fetch_subreddit_post(
+            subreddit=subreddit,
+            post_id=post_id,
+            sort=sort,
+            limit=limit,
+            depth=depth,
+        )
+
+    async def fetch_more_comments(
+        self,
+        post_id: str,
+        comment_ids: List[str],
+        sort: str = "confidence",
+    ) -> RedditCommentsOutput:
+        """Expand comment IDs from a post's `more_comment_ids` field."""
+        try:
+            response = await self.reddit_fetcher.fetch_more_comments(
+                post_id=post_id,
+                comment_ids=comment_ids,
+                sort=sort,
+            )
+            things = response.get("json", {}).get("data", {}).get("things", [])
+            return RedditCommentsOutput(
+                post_id=post_id.removeprefix("t3_"),
+                comments=self._parse_reddit_comments(things),
+                more_comment_ids=self._collect_more_comment_ids(things),
+                success=True,
+            )
+        except SearchException as e:
+            raise ToolError(f"Failed to expand Reddit comments: {str(e)}")
+        except Exception as e:
+            raise ToolError(f"Unexpected error: {str(e)}")
+
+    async def fetch_subreddit_info(self, subreddit: str) -> SubredditInfoOutput:
+        """Fetch public metadata describing a subreddit."""
+        try:
+            response = await self.reddit_fetcher.fetch_subreddit_info(subreddit)
+            data = response.get("data", {})
+            return SubredditInfoOutput(
+                display_name=data.get("display_name", subreddit),
+                title=data.get("title", ""),
+                public_description=data.get("public_description", ""),
+                subscribers=data.get("subscribers"),
+                active_user_count=data.get("active_user_count"),
+                created_utc=data.get("created_utc"),
+                over18=data.get("over18", False),
+                quarantined=data.get("quarantine", False),
+                subreddit_type=data.get("subreddit_type"),
+                url=data.get("url", f"/r/{subreddit}/"),
+                icon_img=data.get("icon_img") or None,
+                banner_img=data.get("banner_img") or None,
+                success=True,
+            )
+        except SearchException as e:
+            raise ToolError(f"Failed to fetch subreddit info: {str(e)}")
         except Exception as e:
             raise ToolError(f"Unexpected error: {str(e)}")

--- a/src/server/handlers.py
+++ b/src/server/handlers.py
@@ -245,7 +245,7 @@ class SearchHandlers:
                 body=comment_data.get("body", ""),
                 parent_id=parent_id,
                 created_utc=comment_data.get("created_utc", 0),
-                depth=depth
+                depth=comment_data.get("depth", depth),
             )
             comments.append(comment)
             
@@ -481,7 +481,9 @@ class SearchHandlers:
     ) -> RedditPostOutput:
         """Fetch a post from its URL, permalink, redd.it URL, or post ID."""
         try:
-            post_id, subreddit = self.reddit_fetcher.parse_post_reference(reference)
+            post_id, subreddit = await self.reddit_fetcher.resolve_post_reference(
+                reference
+            )
         except SearchException as e:
             raise ToolError(f"Invalid Reddit post reference: {str(e)}")
         return await self.fetch_subreddit_post(

--- a/src/server/handlers.py
+++ b/src/server/handlers.py
@@ -356,9 +356,9 @@ class SearchHandlers:
         except Exception as e:
             raise ToolError(f"Unexpected error: {str(e)}")
     
-    async def fetch_subreddit_post(
+    async def _fetch_reddit_post_by_id(
         self,
-        subreddit: str,
+        subreddit: str | None,
         post_id: str,
         sort: str = "confidence",
         limit: int = 100,
@@ -486,7 +486,7 @@ class SearchHandlers:
             )
         except SearchException as e:
             raise ToolError(f"Invalid Reddit post reference: {str(e)}")
-        return await self.fetch_subreddit_post(
+        return await self._fetch_reddit_post_by_id(
             subreddit=subreddit,
             post_id=post_id,
             sort=sort,

--- a/src/server/mcp_server.py
+++ b/src/server/mcp_server.py
@@ -210,57 +210,6 @@ async def fetch_subreddit(
 
 
 @mcp.tool(
-    name="fetch_subreddit_post",
-    tags={"reddit", "post", "comments"},
-    annotations={
-        "title": "Fetch Subreddit Post with Comments",
-        "readOnlyHint": True,
-        "openWorldHint": True,
-        "idempotentHint": False
-    }
-)
-async def fetch_subreddit_post(
-    subreddit: Annotated[str, Field(
-        description="Subreddit name (without r/ prefix, e.g., 'python')",
-        min_length=1,
-        max_length=100
-    )],
-    post_id: Annotated[str, Field(
-        description="Reddit post ID (without t3_ prefix, e.g., '1p6j7ht')",
-        min_length=1,
-        max_length=20
-    )],
-    sort: Annotated[str, Field(
-        description="Comment sort: confidence, top, new, controversial, old, or qa (default: confidence)"
-    )] = "confidence",
-    limit: Annotated[int, Field(
-        description="Maximum comments to fetch (default: 100, min: 1, max: 500)",
-        ge=1,
-        le=500
-    )] = 100,
-    depth: Annotated[int, Field(
-        description="Maximum reply nesting depth (optional, min: 1)"
-    )] = None
-) -> RedditPostOutput:
-    """
-    Fetch a Reddit post with its comments using Reddit's OAuth Data API.
-    
-    Retrieves the post content including title, body, media URLs, and all
-    comments with nested replies maintaining parent-child relationships.
-    
-    Returns:
-        RedditPostOutput with detailed post and comment tree
-    """
-    return await handlers.fetch_subreddit_post(
-        subreddit=subreddit,
-        post_id=post_id,
-        sort=sort,
-        limit=limit,
-        depth=depth
-    )
-
-
-@mcp.tool(
     name="search_reddit",
     tags={"reddit", "search", "posts"},
     annotations={

--- a/src/server/mcp_server.py
+++ b/src/server/mcp_server.py
@@ -16,7 +16,10 @@ from ..core.models import (
     FetchContentOutput, 
     YouTubeContentOutput,
     SubredditPostsOutput,
-    RedditPostOutput
+    RedditPostOutput,
+    RedditSearchOutput,
+    RedditCommentsOutput,
+    SubredditInfoOutput,
 )
 
 
@@ -255,6 +258,144 @@ async def fetch_subreddit_post(
         limit=limit,
         depth=depth
     )
+
+
+@mcp.tool(
+    name="search_reddit",
+    tags={"reddit", "search", "posts"},
+    annotations={
+        "title": "Search Reddit Posts",
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+)
+async def search_reddit(
+    query: Annotated[str, Field(
+        description="Search query",
+        min_length=1,
+        max_length=500,
+    )],
+    subreddit: Annotated[Optional[str], Field(
+        description="Optional subreddit name; omit to search all of Reddit",
+        max_length=100,
+    )] = None,
+    sort: Annotated[str, Field(
+        description="Sort: relevance, hot, top, new, or comments",
+    )] = "relevance",
+    time_filter: Annotated[Optional[str], Field(
+        description="Time filter: hour, day, week, month, year, or all",
+    )] = None,
+    limit: Annotated[int, Field(
+        description="Number of posts to return",
+        ge=1,
+        le=100,
+    )] = 25,
+    after: Annotated[Optional[str], Field(
+        description="Pagination cursor from a previous search",
+    )] = None,
+) -> RedditSearchOutput:
+    """Search public Reddit posts globally or within one subreddit."""
+    return await handlers.search_reddit(
+        query=query,
+        subreddit=subreddit,
+        sort=sort,
+        time_filter=time_filter,
+        limit=limit,
+        after=after,
+    )
+
+
+@mcp.tool(
+    name="fetch_reddit_post",
+    tags={"reddit", "post", "comments", "url"},
+    annotations={
+        "title": "Fetch Reddit Post by URL or ID",
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+)
+async def fetch_reddit_post(
+    reference: Annotated[str, Field(
+        description="Reddit post URL, permalink, redd.it URL, or post ID",
+        min_length=1,
+        max_length=500,
+    )],
+    sort: Annotated[str, Field(
+        description="Comment sort: confidence, top, new, controversial, old, or qa",
+    )] = "confidence",
+    limit: Annotated[int, Field(
+        description="Maximum comments to fetch",
+        ge=1,
+        le=500,
+    )] = 100,
+    depth: Annotated[Optional[int], Field(
+        description="Maximum reply nesting depth",
+        ge=1,
+    )] = None,
+) -> RedditPostOutput:
+    """Fetch a Reddit post and comments from a URL, permalink, or post ID."""
+    return await handlers.fetch_reddit_post(
+        reference=reference,
+        sort=sort,
+        limit=limit,
+        depth=depth,
+    )
+
+
+@mcp.tool(
+    name="fetch_more_comments",
+    tags={"reddit", "comments", "thread"},
+    annotations={
+        "title": "Expand Reddit Comments",
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+)
+async def fetch_more_comments(
+    post_id: Annotated[str, Field(
+        description="Reddit post ID, with or without the t3_ prefix",
+        min_length=1,
+        max_length=20,
+    )],
+    comment_ids: Annotated[List[str], Field(
+        description="Comment IDs from a post's more_comment_ids field",
+        min_length=1,
+        max_length=100,
+    )],
+    sort: Annotated[str, Field(
+        description="Comment sort: confidence, top, new, controversial, old, or qa",
+    )] = "confidence",
+) -> RedditCommentsOutput:
+    """Expand omitted comments using IDs returned by a post fetch."""
+    return await handlers.fetch_more_comments(
+        post_id=post_id,
+        comment_ids=comment_ids,
+        sort=sort,
+    )
+
+
+@mcp.tool(
+    name="fetch_subreddit_info",
+    tags={"reddit", "subreddit", "metadata"},
+    annotations={
+        "title": "Fetch Subreddit Information",
+        "readOnlyHint": True,
+        "openWorldHint": True,
+        "idempotentHint": True,
+    },
+)
+async def fetch_subreddit_info(
+    subreddit: Annotated[str, Field(
+        description="Subreddit name without the r/ prefix",
+        min_length=1,
+        max_length=100,
+    )],
+) -> SubredditInfoOutput:
+    """Fetch public metadata for a subreddit."""
+    return await handlers.fetch_subreddit_info(subreddit)
 
 
 def resolve_transport(cli_http=False, cli_sse=False, env_transport=None):

--- a/src/server/mcp_server.py
+++ b/src/server/mcp_server.py
@@ -318,7 +318,7 @@ async def search_reddit(
 )
 async def fetch_reddit_post(
     reference: Annotated[str, Field(
-        description="Reddit post URL, permalink, redd.it URL, or post ID",
+        description="Reddit post URL, /s/ share URL, permalink, redd.it URL, or post ID",
         min_length=1,
         max_length=500,
     )],
@@ -335,7 +335,7 @@ async def fetch_reddit_post(
         ge=1,
     )] = None,
 ) -> RedditPostOutput:
-    """Fetch a Reddit post and comments from a URL, permalink, or post ID."""
+    """Fetch a Reddit post and comments from a URL, share URL, permalink, or post ID."""
     return await handlers.fetch_reddit_post(
         reference=reference,
         sort=sort,

--- a/tests/test_comment_recursion.py
+++ b/tests/test_comment_recursion.py
@@ -192,3 +192,33 @@ class TestCommentRecursionDepth:
         ]
 
         assert self.handlers._collect_more_comment_ids(children) == ["abc", "def", "ghi"]
+
+    def test_uses_reddit_depth_for_flat_expanded_comments(self):
+        children = [
+            {
+                "kind": "t1",
+                "data": {
+                    "id": "parent",
+                    "author": "user1",
+                    "body": "Parent",
+                    "parent_id": "t1_outside",
+                    "created_utc": 1,
+                    "depth": 4,
+                },
+            },
+            {
+                "kind": "t1",
+                "data": {
+                    "id": "child",
+                    "author": "user2",
+                    "body": "Child",
+                    "parent_id": "t1_parent",
+                    "created_utc": 2,
+                    "depth": 5,
+                },
+            },
+        ]
+
+        comments = self.handlers._parse_reddit_comments(children)
+
+        assert [comment.depth for comment in comments] == [4, 5]

--- a/tests/test_comment_recursion.py
+++ b/tests/test_comment_recursion.py
@@ -173,3 +173,22 @@ class TestCommentRecursionDepth:
             d = c.model_dump()
             assert "depth" in d
             assert "replies" not in d
+
+    def test_collects_nested_more_comment_ids(self):
+        children = [
+            {
+                "kind": "t1",
+                "data": {
+                    "replies": {
+                        "data": {
+                            "children": [
+                                {"kind": "more", "data": {"children": ["abc", "def"]}}
+                            ]
+                        }
+                    }
+                },
+            },
+            {"kind": "more", "data": {"children": ["def", "ghi"]}},
+        ]
+
+        assert self.handlers._collect_more_comment_ids(children) == ["abc", "def", "ghi"]

--- a/tests/test_reddit_fetcher.py
+++ b/tests/test_reddit_fetcher.py
@@ -96,6 +96,48 @@ def test_parse_post_reference_rejects_non_reddit_url():
 
 
 @pytest.mark.asyncio
+async def test_resolve_post_reference_follows_reddit_share_redirect():
+    fetcher = RedditFetcher()
+    share_url = "https://www.reddit.com/r/python/s/share123"
+    redirect = response(
+        302,
+        headers={
+            "location": "https://www.reddit.com/r/python/comments/1abcde/example_title/"
+        },
+        request_url=share_url,
+    )
+    client = AsyncMock()
+    client.get.return_value = redirect
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+
+    with patch("src.core.reddit_fetcher.httpx.AsyncClient", return_value=client):
+        result = await fetcher.resolve_post_reference(share_url)
+
+    assert result == ("1abcde", "python")
+    assert client.get.await_args.kwargs["follow_redirects"] is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_post_reference_rejects_external_share_redirect():
+    fetcher = RedditFetcher()
+    share_url = "https://www.reddit.com/r/python/s/share123"
+    redirect = response(
+        302,
+        headers={"location": "https://example.com/r/python/comments/1abcde/title/"},
+        request_url=share_url,
+    )
+    client = AsyncMock()
+    client.get.return_value = redirect
+    client.__aenter__.return_value = client
+    client.__aexit__.return_value = None
+
+    with patch("src.core.reddit_fetcher.httpx.AsyncClient", return_value=client):
+        with pytest.raises(SearchException, match="outside Reddit"):
+            await fetcher.resolve_post_reference(share_url)
+
+
+@pytest.mark.asyncio
 async def test_search_posts_scopes_to_subreddit():
     fetcher = RedditFetcher()
     fetcher._get = AsyncMock(return_value=response(200, {"kind": "Listing"}))

--- a/tests/test_reddit_fetcher.py
+++ b/tests/test_reddit_fetcher.py
@@ -69,3 +69,71 @@ async def test_rate_limit_reports_reset_time():
     with patch("src.core.reddit_fetcher.httpx.AsyncClient", return_value=client):
         with pytest.raises(SearchException, match="42 seconds"):
             await fetcher.fetch_subreddit_posts("python")
+
+
+@pytest.mark.parametrize(
+    ("reference", "post_id", "subreddit"),
+    [
+        ("1abcde", "1abcde", None),
+        ("t3_1abcde", "1abcde", None),
+        ("https://redd.it/1abcde", "1abcde", None),
+        (
+            "https://www.reddit.com/r/python/comments/1abcde/example_title/",
+            "1abcde",
+            "python",
+        ),
+        ("/r/python/comments/1abcde/example_title/", "1abcde", "python"),
+        ("https://www.reddit.com/comments/a/old_post/", "a", None),
+    ],
+)
+def test_parse_post_reference(reference, post_id, subreddit):
+    assert RedditFetcher.parse_post_reference(reference) == (post_id, subreddit)
+
+
+def test_parse_post_reference_rejects_non_reddit_url():
+    with pytest.raises(SearchException, match="Reddit post URL"):
+        RedditFetcher.parse_post_reference("https://example.com/comments/1abcde")
+
+
+@pytest.mark.asyncio
+async def test_search_posts_scopes_to_subreddit():
+    fetcher = RedditFetcher()
+    fetcher._get = AsyncMock(return_value=response(200, {"kind": "Listing"}))
+
+    result = await fetcher.search_posts(
+        "asyncio",
+        subreddit="python",
+        sort="top",
+        time_filter="week",
+        limit=10,
+    )
+
+    assert result["kind"] == "Listing"
+    url, params = fetcher._get.await_args.args
+    assert url == "https://oauth.reddit.com/r/python/search.json"
+    assert params["restrict_sr"] == "on"
+    assert params["q"] == "asyncio"
+    assert params["t"] == "week"
+
+
+@pytest.mark.asyncio
+async def test_fetch_more_comments_builds_morechildren_request():
+    fetcher = RedditFetcher()
+    fetcher._get = AsyncMock(return_value=response(200, {"json": {"data": {"things": []}}}))
+
+    await fetcher.fetch_more_comments("t3_1abcde", ["t1_def456", "ghi789"])
+
+    url, params = fetcher._get.await_args.args
+    assert url == "https://oauth.reddit.com/api/morechildren"
+    assert params["link_id"] == "t3_1abcde"
+    assert params["children"] == "def456,ghi789"
+
+
+@pytest.mark.asyncio
+async def test_fetch_subreddit_info_uses_about_endpoint():
+    fetcher = RedditFetcher()
+    fetcher._get = AsyncMock(return_value=response(200, {"kind": "t5", "data": {}}))
+
+    await fetcher.fetch_subreddit_info("python")
+
+    assert fetcher._get.await_args.args[0] == "https://oauth.reddit.com/r/python/about.json"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,7 +3,7 @@ Tests for server functionality
 """
 
 import pytest
-from unittest.mock import patch, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 from src.server.handlers import SearchHandlers
 from src.core.config import SearchException
@@ -90,3 +90,37 @@ class TestSearchHandlers:
         
         # Verify error message
         assert 'Unexpected error' in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_fetch_reddit_post_resolves_reference_and_fetches_by_id(self):
+        expected = Mock()
+        self.handlers.reddit_fetcher.resolve_post_reference = AsyncMock(
+            return_value=("1abcde", "python")
+        )
+        self.handlers._fetch_reddit_post_by_id = AsyncMock(return_value=expected)
+
+        result = await self.handlers.fetch_reddit_post(
+            reference="https://www.reddit.com/r/python/comments/1abcde/example/",
+            sort="top",
+            limit=50,
+            depth=3,
+        )
+
+        assert result is expected
+        self.handlers._fetch_reddit_post_by_id.assert_awaited_once_with(
+            subreddit="python",
+            post_id="1abcde",
+            sort="top",
+            limit=50,
+            depth=3,
+        )
+
+
+@pytest.mark.asyncio
+async def test_reddit_post_is_exposed_as_one_tool():
+    from src.server.mcp_server import mcp
+
+    tool_names = {tool.name for tool in await mcp.list_tools()}
+
+    assert "fetch_reddit_post" in tool_names
+    assert "fetch_subreddit_post" not in tool_names


### PR DESCRIPTION
## Summary

- roll the Reddit research tools and JSON documentation from #15 and #16 into `main`
- expose `fetch_reddit_post` as the single tool for fetching Reddit posts and comments
- accept canonical URLs, `/s/` share URLs, permalinks, `redd.it` URLs, and bare post IDs
- remove the redundant `fetch_subreddit_post` tool while retaining one private shared implementation
- update the README so the documented tool list matches the MCP registry

## Verification

- 83 focused unit tests passed
- MCP registry contains `fetch_reddit_post` and does not contain `fetch_subreddit_post`
- README contains 9 tool examples and 18 valid JSON blocks
- GitHub Markdown rendering preserves all 9 side-by-side collapsible example rows
- `git diff --check` passes

## Roll-up

#15 and #16 were merged into their stacked parent branches after those parents had
already merged. This PR targets `main` so those changes, plus the unified Reddit post
tool, land in the default branch together.
