### PR TITLE
fix: fetch XDA pages behind Bunny Shield

### DIFF
--- a/src/core/web_fetcher.py
+++ b/src/core/web_fetcher.py
@@ -16,6 +16,23 @@ class WebContentFetcher:
     _playwright = None
     _browser = None
 
+    _SECURITY_INTERSTITIAL_MARKERS = (
+        "/.bunny-shield/",
+        "bunny_shield",
+        "bunnyshield-challenge-response",
+    )
+    _SECURITY_INTERSTITIAL_PHRASES = (
+        "this website is using a security service to protect itself from online attacks",
+        "we are checking your browser to establish a secure connection",
+        "this website uses a security service to protect against malicious bots",
+        "performing security verification",
+    )
+    _BROWSER_INIT_SCRIPT = """
+        Object.defineProperty(navigator, "webdriver", {
+            get: () => undefined,
+        });
+    """
+
     def __init__(self):
         self.headers = {
             "User-Agent": SearchConfig.USER_AGENT
@@ -38,6 +55,40 @@ class WebContentFetcher:
         if content_start and content_start.startswith(b'%PDF'):
             return True
         return False
+
+    @classmethod
+    def _is_security_interstitial(cls, content: str) -> bool:
+        """Return whether content is a bot/security verification page."""
+        if not content:
+            return False
+
+        normalized = content.casefold()
+        if any(marker in normalized for marker in cls._SECURITY_INTERSTITIAL_MARKERS):
+            return True
+
+        # Challenge pages are short. Restrict phrase matching so an article that
+        # discusses bot protection is not mistaken for an interstitial.
+        return len(content) <= 10_000 and any(
+            phrase in normalized for phrase in cls._SECURITY_INTERSTITIAL_PHRASES
+        )
+
+    @staticmethod
+    def _browser_user_agent(browser) -> str:
+        """Build a normal Chrome UA that matches the bundled Chromium version."""
+        return (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            f"(KHTML, like Gecko) Chrome/{browser.version} Safari/537.36"
+        )
+
+    async def _new_browser_page(self, browser):
+        """Create a browser page with a normal, non-automation profile."""
+        page = await browser.new_page(
+            user_agent=self._browser_user_agent(browser),
+            locale="en-US",
+            viewport={"width": 1365, "height": 768},
+        )
+        await page.add_init_script(self._BROWSER_INIT_SCRIPT)
+        return page
 
     @staticmethod
     def _clean_browser_html(html: str) -> str:
@@ -76,7 +127,7 @@ class WebContentFetcher:
             args=[
                 "--disable-dev-shm-usage",
                 "--no-sandbox",
-                "--single-process",
+                "--disable-blink-features=AutomationControlled",
             ],
         )
         return WebContentFetcher._browser
@@ -105,11 +156,11 @@ class WebContentFetcher:
         """
         browser = await self._ensure_browser()
         try:
-            page = await browser.new_page()
+            page = await self._new_browser_page(browser)
         except Exception:
             # Browser died between check and use — re-launch once
             browser = await self._launch_browser()
-            page = await browser.new_page()
+            page = await self._new_browser_page(browser)
         try:
             timeout_ms = int(SearchConfig.RENDER_TIMEOUT * 1000)
             try:
@@ -137,12 +188,18 @@ class WebContentFetcher:
 
                 is_truncated = False
                 text = response.text
+                if self._is_security_interstitial(text):
+                    raise SearchException(
+                        "Jina Reader returned a security verification interstitial"
+                    )
                 if len(text) > SearchConfig.MAX_CONTENT_LENGTH:
                     text = text[:SearchConfig.MAX_CONTENT_LENGTH] + "... [content truncated]"
                     is_truncated = True
 
                 return text, is_truncated
 
+        except SearchException:
+            raise
         except Exception as e:
             raise SearchException(f"Failed to fetch via Jina Reader: {e}")
 
@@ -216,9 +273,11 @@ class WebContentFetcher:
         """
         try:
             html = await self._render_with_browser(url)
+            if self._is_security_interstitial(html):
+                return None
             html = self._clean_browser_html(html)
             text = self._parse_html_content(html, url=url, favor_recall=True)
-            if text and text.strip():
+            if text and text.strip() and not self._is_security_interstitial(text):
                 return text
         except Exception:
             pass
@@ -270,8 +329,14 @@ class WebContentFetcher:
                 # Parse as HTML with trafilatura
                 text = self._parse_html_content(response.text, url=url)
 
-                # If static extraction returned content, return it
-                if text and text.strip():
+                # If static extraction returned real content, return it. Some
+                # bot challenges use HTTP 200 and otherwise look parseable.
+                if (
+                    text
+                    and text.strip()
+                    and not self._is_security_interstitial(response.text)
+                    and not self._is_security_interstitial(text)
+                ):
                     return self._apply_offset_and_chunk(text, offset)
 
                 # Empty static result → try JS rendering fallback

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -160,7 +160,151 @@ class TestWebContentFetcher:
             text = self.fetcher._parse_html_content(minimal_html)
             assert isinstance(text, str)
 
+    def test_security_interstitial_detection(self):
+        """Recognize Bunny Shield HTML and extracted verification text."""
+        bunny_html = """
+        <html>
+            <script src="/.bunny-shield/assets/shield-challenge.js"></script>
+            <body>We are checking your browser to establish a secure connection.</body>
+        </html>
+        """
+        jina_text = """
+        ## Performing security verification
+
+        This website uses a security service to protect against malicious bots.
+        """
+
+        assert self.fetcher._is_security_interstitial(bunny_html) is True
+        assert self.fetcher._is_security_interstitial(jina_text) is True
+
+    def test_security_interstitial_detection_ignores_normal_noscript_text(self):
+        """Do not reject ordinary pages that merely recommend enabling JS."""
+        content = "JavaScript is disabled. For a better experience, please enable JavaScript."
+
+        assert self.fetcher._is_security_interstitial(content) is False
+
     # --- Auto JS rendering fallback tests ---
+
+    @pytest.mark.asyncio
+    async def test_new_browser_page_uses_non_automation_profile(self):
+        """Browser fallback should not advertise Playwright's default profile."""
+        browser = AsyncMock()
+        browser.version = "149.0.7827.0"
+        page = AsyncMock()
+        browser.new_page.return_value = page
+
+        result = await self.fetcher._new_browser_page(browser)
+
+        browser.new_page.assert_awaited_once_with(
+            user_agent=(
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/149.0.7827.0 Safari/537.36"
+            ),
+            locale="en-US",
+            viewport={"width": 1365, "height": 768},
+        )
+        page.add_init_script.assert_awaited_once_with(self.fetcher._BROWSER_INIT_SCRIPT)
+        assert result is page
+
+    @pytest.mark.asyncio
+    async def test_launch_browser_avoids_single_process_fingerprint(self):
+        """Chromium launch flags should reduce the automation fingerprint."""
+        original_playwright = WebContentFetcher._playwright
+        original_browser = WebContentFetcher._browser
+        manager = AsyncMock()
+        playwright = AsyncMock()
+        browser = AsyncMock()
+        manager.start.return_value = playwright
+        playwright.chromium.launch.return_value = browser
+
+        WebContentFetcher._playwright = None
+        WebContentFetcher._browser = None
+        try:
+            with patch("playwright.async_api.async_playwright", return_value=manager):
+                result = await self.fetcher._launch_browser()
+
+            launch_kwargs = playwright.chromium.launch.await_args.kwargs
+            assert "--disable-blink-features=AutomationControlled" in launch_kwargs["args"]
+            assert "--single-process" not in launch_kwargs["args"]
+            assert result is browser
+        finally:
+            WebContentFetcher._playwright = original_playwright
+            WebContentFetcher._browser = original_browser
+
+    @pytest.mark.asyncio
+    async def test_browser_fallback_rejects_security_interstitial(self):
+        """A rendered challenge page is not successful browser content."""
+        url = "https://example.com/protected"
+        challenge_html = """
+        <html>
+            <script src="/.bunny-shield/assets/shield-challenge.js"></script>
+            <body>Calculating...</body>
+        </html>
+        """
+
+        with patch.object(
+            self.fetcher,
+            "_render_with_browser",
+            new_callable=AsyncMock,
+            return_value=challenge_html,
+        ):
+            with patch.object(self.fetcher, "_parse_html_content") as mock_parse:
+                result = await self.fetcher._try_browser_fallback(url)
+
+        assert result is None
+        mock_parse.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_static_security_interstitial_tries_browser(self):
+        """A parseable HTTP 200 challenge should still use browser fallback."""
+        url = "https://example.com/protected"
+        challenge_html = """
+        <html><body>
+            This website is using a security service to protect itself from online attacks.
+        </body></html>
+        """
+        mock_response = AsyncMock()
+        mock_response.headers = {"content-type": "text/html"}
+        mock_response.content = challenge_html.encode()
+        mock_response.text = challenge_html
+        mock_response.raise_for_status = lambda: None
+
+        with patch("src.core.web_fetcher.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            with patch.object(
+                self.fetcher,
+                "_try_browser_fallback",
+                new_callable=AsyncMock,
+                return_value="Rendered article content",
+            ) as mock_browser:
+                content, _, _, _ = await self.fetcher.fetch_and_parse(url)
+
+        mock_browser.assert_awaited_once_with(url)
+        assert content == "Rendered article content"
+
+    @pytest.mark.asyncio
+    async def test_jina_rejects_security_interstitial(self):
+        """Jina verification text should raise instead of becoming success output."""
+        url = "https://example.com/protected"
+        mock_response = AsyncMock()
+        mock_response.text = (
+            "## Performing security verification\n\n"
+            "This website uses a security service to protect against malicious bots."
+        )
+        mock_response.raise_for_status = lambda: None
+
+        with patch("src.core.web_fetcher.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            with pytest.raises(SearchException, match="security verification interstitial"):
+                await self.fetcher._fetch_via_jina(url)
 
     @pytest.mark.asyncio
     async def test_browser_fallback_on_empty_static(self):


### PR DESCRIPTION
## Summary

- harden the Playwright fallback with a Chromium-matched Chrome user agent and a less automation-specific browser profile
- remove the `--single-process` fingerprint, disable Blink's automation-controlled flag, and hide `navigator.webdriver`
- detect Bunny Shield and similar security interstitials in static, browser-rendered, and Jina content so they are not returned as successful fetches
- add regression coverage for the browser profile and each interstitial path

## Verification

- 20 deterministic fetch tests passed, including all new regressions
- 89 remaining non-integration unit tests passed
- Docker image builds successfully and `python -m compileall -q src` passes
- live `SearchHandlers.fetch_content()` test against the reported XDA page returned real page-4 content:
  - `success: true`
  - `content_length: 30000`
  - `is_truncated: true`
  - `next_offset: 30000`
  - known page-4 post text present
  - no security-interstitial markers present

Exact test URL:

`https://xdaforums.com/t/unlock-root-twrp-unbrick-amazon-echo-dot-2nd-gen-2016-biscuit.4761416/page-4`

## Test-suite note

The complete live fetch suite currently has two unrelated external-fixture failures: Jina returns HTTP 403 for the existing Q4 CDN PDF used by `test_fetch_pdf_content` and `test_pagination_with_offset`. No PDF/Jina request behavior was changed except rejecting verification-interstitial text as successful content.
